### PR TITLE
Skip writing identical RBS files

### DIFF
--- a/lib/rbs/inline/cli.rb
+++ b/lib/rbs/inline/cli.rb
@@ -117,7 +117,7 @@ module RBS
               output = output_file_path.sub_ext(".rbs")
             else
               raise "Cannot calculate the output file path for #{target} in #{output_path}: calculated = #{output}"
-            end 
+            end
 
             logger.debug { "Generating #{output} from #{target} ..." }
           else
@@ -137,14 +137,18 @@ module RBS
                 output.parent.mkpath
               end
 
-              logger.debug { "Writing RBS file to #{output}..." }
-              output.write(writer.output)
+              if output.file? && output.read == writer.output
+                logger.debug { "Skip writing identical RBS file" }
+              else
+                logger.debug { "Writing RBS file to #{output}..." }
+                output.write(writer.output)
+                count += 1
+              end
             else
               stdout.puts writer.output
               stdout.puts
+              count += 1
             end
-
-            count += 1
           else
             logger.debug { "Skipping #{target} because `# rbs_inline: enabled` comment not found" }
           end

--- a/test/rbs/inline/cli_test.rb
+++ b/test/rbs/inline/cli_test.rb
@@ -86,4 +86,30 @@ class RBS::Inline::CLITest < Minitest::Test
       end
     end
   end
+
+  def test_cli__skip_identical_rbs_file
+    with_tmpdir do |pwd|
+      Dir.chdir(pwd.to_s) do
+        cli = CLI.new(stdout: stdout, stderr: stderr)
+
+        lib = pwd + "lib"
+        lib.mkpath
+
+        (lib + "foo.rb").write(<<~RUBY)
+          # rbs_inline: enabled
+
+          class Hello
+          end
+        RUBY
+
+        cli.run(%w(lib -v --output=sig))
+        assert_match /Writing RBS file to/, stderr.string
+
+        stderr.truncate(0)
+
+        cli.run(%w(lib -v --output=sig))
+        assert_match /Skip writing identical RBS file/, stderr.string
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changing a file starts Steep type checking even if the content is not changed. So, skipping writing identical RBS file would improve the performance.