### PR TITLE
Add `--opt-in` and `--opt-out` options

### DIFF
--- a/lib/rbs/inline/cli.rb
+++ b/lib/rbs/inline/cli.rb
@@ -72,6 +72,7 @@ module RBS
       def run(args)
         base_paths = [Pathname("lib"), Pathname("app")]
         output_path = nil #: Pathname?
+        opt_in = true
 
         OptionParser.new do |opts|
           opts.on("--base=[BASE]", "The path to calculate relative path of files (defaults to #{base_paths.join(File::PATH_SEPARATOR)})") do |str|
@@ -81,6 +82,14 @@ module RBS
 
           opts.on("--output=[BASE]", "The directory where the RBS files are saved at (defaults to STDOUT if not specified)") do
             output_path = Pathname(_1)
+          end
+
+          opts.on("--opt-out", "Generates RBS files by default. Opt-out with `# rbs_inline: disabled` comment") do
+            opt_in = false
+          end
+
+          opts.on("--opt-in", "Generates RBS files only for files with `# rbs_inline: enabled` comment (default)") do
+            opt_in = true
           end
 
           opts.on("--verbose") do
@@ -126,7 +135,7 @@ module RBS
 
           logger.debug { "Parsing ruby file #{target}..." }
 
-          if (uses, decls = Parser.parse(Prism.parse_file(target.to_s)))
+          if (uses, decls = Parser.parse(Prism.parse_file(target.to_s), opt_in: opt_in))
             writer = Writer.new()
             writer.header("Generated from #{target.relative? ? target : target.relative_path_from(Pathname.pwd)} with RBS::Inline")
             writer.write(uses, decls)

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -31,8 +31,9 @@ module RBS
       def initialize: () -> void
 
       # @rbs result: ParseResult[ProgramNode]
+      # @rbs opt_in: bool -- `true` for *opt-out* mode, `false` for *opt-in* mode.
       # @rbs returns [Array[AST::Annotations::Use], Array[AST::Declarations::t]]?
-      def self.parse: (ParseResult[ProgramNode] result) -> [ Array[AST::Annotations::Use], Array[AST::Declarations::t] ]?
+      def self.parse: (ParseResult[ProgramNode] result, opt_in: bool) -> [ Array[AST::Annotations::Use], Array[AST::Declarations::t] ]?
 
       # @rbs returns AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | nil
       def current_class_module_decl: () -> (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | nil)

--- a/test/rbs/inline/parser_test.rb
+++ b/test/rbs/inline/parser_test.rb
@@ -10,7 +10,7 @@ class RBS::Inline::ParserTest < Minitest::Test
   end
 
   def test_class_decl
-    Parser.parse(parse_ruby(<<~RUBY))
+    Parser.parse(parse_ruby(<<~RUBY), opt_in: false)
       class Foo
         # Hello world
         class Bar < Object
@@ -22,25 +22,28 @@ class RBS::Inline::ParserTest < Minitest::Test
   end
 
   def test_stop_parsing
-    assert_nil Parser.parse(parse_ruby(<<~RUBY))
+    assert_nil Parser.parse(parse_ruby(<<~RUBY), opt_in: false)
+      # rbs_inline: disabled
+      class Foo
+      end
+    RUBY
+
+    assert_nil Parser.parse(parse_ruby(<<~RUBY), opt_in: true)
       class Foo
       end
     RUBY
   end
 
-  def test_continue_parsing__magic_comment
-    refute_nil Parser.parse(parse_ruby(<<~RUBY))
+  def test_continue_parsing
+    refute_nil Parser.parse(parse_ruby(<<~RUBY), opt_in: true)
       # rbs_inline: enabled
 
       class Foo
       end
     RUBY
-  end
 
-  def test_continue_parsing__annotation
-    refute_nil Parser.parse(parse_ruby(<<~RUBY))
+    refute_nil Parser.parse(parse_ruby(<<~RUBY), opt_in: false)
       class Foo
-        attr_reader :foo #:: String
       end
     RUBY
   end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -5,9 +5,9 @@ require "test_helper"
 class RBS::Inline::WriterTest < Minitest::Test
   include RBS::Inline
 
-  def translate(src)
+  def translate(src, opt_in: true)
     src = "# rbs_inline: enabled\n\n" + src
-    uses, decls = Parser.parse(Prism.parse(src, filepath: "a.rb"))
+    uses, decls = Parser.parse(Prism.parse(src, filepath: "a.rb"), opt_in: opt_in)
     Writer.write(uses, decls)
   end
 


### PR DESCRIPTION
Add `--opt-in` and `--opt-out` commandline option to control whether to generate or skip Ruby code, without magic comments.

* `--opt-in` means Ruby scripts without `# rbs_inline: enabled` magic comment is skipped
* `--opt-out` means Ruby scripts without `# rbs_inline: disabled` magic comment is generated

The detection based on if RBS::Inline annotations are included or not is deleted. (#18)