### PR TITLE
Fix an error that occurs in the nested module

### DIFF
--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -378,7 +378,8 @@ module RBS
             return unless node.arguments.arguments.size == 1
 
             arg = node.arguments.arguments[0] || raise
-            type_name = type_name(arg) || raise
+            type_name = type_name(arg)
+            return unless type_name
 
             args = [] #: Array[Types::t]
             if application

--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -346,6 +346,8 @@ module RBS
         end
 
         class RubyMixin < RubyBase
+          include Declarations::ConstantUtil
+
           # CallNode that calls `include`, `prepend`, and `extend` method
           attr_reader :node #:: Prism::CallNode
 
@@ -376,11 +378,7 @@ module RBS
             return unless node.arguments.arguments.size == 1
 
             arg = node.arguments.arguments[0] || raise
-            if arg.is_a?(Prism::ConstantReadNode)
-              type_name = RBS::TypeName.new(name: arg.name, namespace: RBS::Namespace.empty)
-            else
-              raise
-            end
+            type_name = type_name(arg) || raise
 
             args = [] #: Array[Types::t]
             if application

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -585,4 +585,17 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_include_dynamic_values
+    output = translate(<<~RUBY)
+      class A
+        include Module.new
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class A
+      end
+    RBS
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -561,4 +561,28 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_include_nested_modules
+    output = translate(<<~RUBY)
+      module M
+        module A
+        end
+      end
+
+      class Foo
+        include M::A
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      module M
+        module A
+        end
+      end
+
+      class Foo
+        include M::A
+      end
+    RBS
+  end
 end


### PR DESCRIPTION
Specifying the Ruby file containing the nested module will cause an error of `unhandled exception`.
When this error occurs, `arg` in `RubyMixin#rbs` becomes `Prism::ConstantPathNode`.

To support this node, change to use `ConstantUtil#type_name`.

fixes #27