### PR TITLE
Add dependency on Steep 1.7.0.dev

### DIFF
--- a/rbs-inline.gemspec
+++ b/rbs-inline.gemspec
@@ -30,4 +30,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "prism", ">= 0.29", "< 0.30"
   spec.add_dependency "rbs", "~> 3.5.0.pre"
+  # NOTE: rbs-inline outputs syntax that is added from RBS 3.5 and Steep 1.7.
+  #       Once RBS 3.5 is released, this dependency can be removed.
+  # ref. https://github.com/soutaro/rbs-inline/issues/41
+  spec.add_dependency "steep", "~> 1.7.0.dev"
 end


### PR DESCRIPTION
Added a dependency on Steep 1.7.0.dev to support new syntax introduced in RBS 3.5 and Steep 1.7. 
This change includes a note that explains the dependency can be removed once RBS 3.5 is officially released.