### PR TITLE
Revise comment line grouping

### DIFF
--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -15,9 +15,9 @@ module RBS
           end
         end
 
-        # @rbs! type t = ClassDecl | ModuleDecl | ConstantDecl | SingletonClassDecl
-
         # @rbs!
+        #   type t = ClassDecl | ModuleDecl | ConstantDecl | SingletonClassDecl
+        #
         #  interface _WithComments
         #    def comments: () -> AnnotationParser::ParsingResult?
         #  end
@@ -27,7 +27,7 @@ module RBS
           # @rbs returns Array[RBS::AST::TypeParam]
           def type_params
             if comments = comments()
-              comments.annotations.filter_map do |annotation|
+              comments.each_annotation.filter_map do |annotation|
                 if annotation.is_a?(Annotations::Generic)
                   annotation.type_param
                 end
@@ -63,7 +63,7 @@ module RBS
           # Type parameters for the declaration
           def type_params #:: Array[RBS::AST::TypeParam]
             if comments = comments()
-              comments.annotations.filter_map do |annotation|
+              comments.each_annotation.filter_map do |annotation|
                 if annotation.is_a?(Annotations::Generic)
                   annotation.type_param
                 end
@@ -102,7 +102,7 @@ module RBS
           # @rbs %a{pure}
           def super_class #:: RBS::AST::Declarations::Class::Super?
             if comments
-              if inherits = comments.annotations.find {|a| a.is_a?(Annotations::Inherits) } #: Annotations::Inherits?
+              if inherits = comments.each_annotation.find {|a| a.is_a?(Annotations::Inherits) } #: Annotations::Inherits?
                 super_name = inherits.super_name
                 super_args = inherits.args
 
@@ -148,7 +148,7 @@ module RBS
           # @rbs %a{pure}
           def module_selfs #:: Array[Annotations::ModuleSelf]
             if comments
-              comments.annotations.filter_map do |ann|
+              comments.each_annotation.filter_map do |ann|
                 if ann.is_a?(AST::Annotations::ModuleSelf)
                   ann
                 end

--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -6,7 +6,9 @@ module RBS
       module Members
         # @rbs!
         #   type ruby = RubyDef | RubyAlias | RubyMixin | RubyAttr | RubyPublic | RubyPrivate
+        #
         #   type rbs = RBSIvar | RBSEmbedded
+        #
         #   type t = ruby | rbs
 
         class Base
@@ -61,7 +63,7 @@ module RBS
 
           def method_type_annotations #:: Array[Annotations::Assertion]
             if comments
-              comments.annotations.select do |annotation|
+              comments.each_annotation.select do |annotation|
                 annotation.is_a?(Annotations::Assertion) && annotation.type.is_a?(MethodType)
               end #: Array[Annotations::Assertion]
             else
@@ -76,7 +78,7 @@ module RBS
               end
             end
             if comments
-              annot = comments.annotations.find {|annot| annot.is_a?(Annotations::ReturnType ) } #: Annotations::ReturnType?
+              annot = comments.each_annotation.find {|annot| annot.is_a?(Annotations::ReturnType ) } #: Annotations::ReturnType?
               if annot
                 annot.type
               end
@@ -87,7 +89,7 @@ module RBS
             types = {} #: Hash[Symbol, Types::t?]
 
             if comments
-              comments.annotations.each do |annotation|
+              comments.each_annotation.each do |annotation|
                 if annotation.is_a?(Annotations::VarType)
                   name = annotation.name
                   type = annotation.type
@@ -262,7 +264,7 @@ module RBS
 
           def method_annotations #:: Array[RBS::AST::Annotation]
             if comments
-              comments.annotations.flat_map do |annotation|
+              comments.each_annotation.flat_map do |annotation|
                 if annotation.is_a?(AST::Annotations::RBSAnnotation)
                   annotation.contents.map do |string|
                     RBS::AST::Annotation.new(
@@ -281,7 +283,7 @@ module RBS
 
           def override_annotation #:: AST::Annotations::Override?
             if comments
-              comments.annotations.find do |annotation|
+              comments.each_annotation.find do |annotation|
                 annotation.is_a?(AST::Annotations::Override)
               end #: AST::Annotations::Override?
             end
@@ -289,7 +291,7 @@ module RBS
 
           def yields_annotation #:: AST::Annotations::Yields?
             if comments
-              comments.annotations.find do |annotation|
+              comments.each_annotation.find do |annotation|
                 annotation.is_a?(AST::Annotations::Yields)
               end #: AST::Annotations::Yields?
             end
@@ -416,7 +418,7 @@ module RBS
           # @rbs return Array[RBS::AST::Members::AttrReader | RBS::AST::Members::AttrWriter | RBS::AST::Members::AttrAccessor]?
           def rbs
             if comments
-              comment = RBS::AST::Comment.new(string: comments.content, location: nil)
+              comment = RBS::AST::Comment.new(string: comments.content(trim: true), location: nil)
             end
 
             klass =

--- a/lib/rbs/inline/ast/tree.rb
+++ b/lib/rbs/inline/ast/tree.rb
@@ -6,6 +6,7 @@ module RBS
       class Tree
         # @rbs!
         #   type token = [Symbol, String]
+        #
         #   type tree = token | Tree | Types::t | MethodType | nil
 
         attr_reader :trees #:: Array[tree]

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -61,7 +61,7 @@ module RBS
 
         uses = [] #: Array[AST::Annotations::Use]
         annots.each do |annot|
-          annot.annotations.each do |annotation|
+          annot.each_annotation do |annotation|
             if annotation.is_a?(AST::Annotations::Use)
               uses << annotation
             end
@@ -118,7 +118,7 @@ module RBS
         comments = inner_annotations(start_line, end_line)
 
         comments.each do |comment|
-          comment.annotations.each do |annotation|
+          comment.each_annotation do |annotation|
             case annotation
             when AST::Annotations::IvarType
               members << AST::Members::RBSIvar.new(comment, annotation)
@@ -256,7 +256,7 @@ module RBS
             end
             if assertion_comment && comment_line
               comments.delete(comment_line)
-              assertion = assertion_comment.annotations.find do |annotation|
+              assertion = assertion_comment.each_annotation.find do |annotation|
                 annotation.is_a?(AST::Annotations::Assertion)
               end #: AST::Annotations::Assertion?
             end
@@ -313,7 +313,7 @@ module RBS
       # @rbs returns bool
       def ignored_node?(node)
         if comment = comments.fetch(node.location.start_line - 1, nil)
-          comment.annotations.any? { _1.is_a?(AST::Annotations::Skip) }
+          comment.each_annotation.any? { _1.is_a?(AST::Annotations::Skip) }
         else
           false
         end
@@ -332,7 +332,7 @@ module RBS
 
         if app_comment && comment_line
           comments.delete(comment_line)
-          app_comment.annotations.find do |annotation|
+          app_comment.each_annotation.find do |annotation|
             annotation.is_a?(AST::Annotations::Application)
           end #: AST::Annotations::Application?
         end
@@ -356,7 +356,7 @@ module RBS
 
         if app_comment && comment_line
           comments.delete(comment_line)
-          app_comment.annotations.find do |annotation|
+          app_comment.each_annotation.find do |annotation|
             annotation.is_a?(AST::Annotations::Assertion)
           end #: AST::Annotations::Assertion?
         end

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -66,7 +66,7 @@ module RBS
         return unless decl.class_name
 
         if decl.comments
-          comment = RBS::AST::Comment.new(string: decl.comments.content, location: nil)
+          comment = RBS::AST::Comment.new(string: decl.comments.content(trim: true), location: nil)
         end
 
         members = [] #: Array[RBS::AST::Members::t | RBS::AST::Declarations::t]
@@ -104,7 +104,7 @@ module RBS
         return unless decl.module_name
 
         if decl.comments
-          comment = RBS::AST::Comment.new(string: decl.comments.content, location: nil)
+          comment = RBS::AST::Comment.new(string: decl.comments.content(trim: true), location: nil)
         end
 
         members = [] #: Array[RBS::AST::Members::t | RBS::AST::Declarations::t]
@@ -144,7 +144,7 @@ module RBS
         return unless decl.constant_name
 
         if decl.comments
-          comment = RBS::AST::Comment.new(string: decl.comments.content, location: nil)
+          comment = RBS::AST::Comment.new(string: decl.comments.content(trim: true), location: nil)
         end
 
         RBS::AST::Declarations::Constant.new(
@@ -178,7 +178,7 @@ module RBS
         case member
         when AST::Members::RubyDef
           if member.comments
-            comment = RBS::AST::Comment.new(string: member.comments.content, location: nil)
+            comment = RBS::AST::Comment.new(string: member.comments.content(trim: true), location: nil)
           end
 
           kind = method_kind(member, decl)
@@ -212,7 +212,7 @@ module RBS
           ]
         when AST::Members::RubyAlias
           if member.comments
-            comment = RBS::AST::Comment.new(string: member.comments.content, location: nil)
+            comment = RBS::AST::Comment.new(string: member.comments.content(trim: true), location: nil)
           end
 
           [

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -3,12 +3,32 @@
 module RBS
   module Inline
     class AnnotationParser
+      # ParsingResut groups consecutive comments, which may contain several annotations
+      #
+      # *Consecutive comments* are comments are defined in below.
+      # They are basically comments that follows from the previous line, but there are some more requirements.
+      #
+      # ```ruby
+      # # Line 1
+      # # Line 2           #=> Line 1 and Line 2 are consecutive
+      #
+      #    # Line 3
+      #  # Line4           #=> Line 3 and Line 4 are not consecutive, because the starting column are different
+      #
+      #         # Line 5
+      # foo()   # Line 6   #=> Line 5 and Line 6 are not consecutive, because Line 6 has leading code
+      # ```
       class ParsingResult
         attr_reader comments: Array[Prism::Comment]
 
-        attr_reader annotations: Array[AST::Annotations::t]
+        attr_reader annotations: Array[AST::Annotations::t | AST::CommentLines]
 
         attr_reader first_comment_offset: Integer
+
+        # :: () { (AST::Annotations::t) -> void } -> void
+        # :: () -> Enumerator[AST::Annotations::t, void]
+        def each_annotation: () { (AST::Annotations::t) -> void } -> void
+                           | () -> Enumerator[AST::Annotations::t, void]
 
         # @rbs first_comment: Prism::Comment
         def initialize: (Prism::Comment first_comment) -> untyped
@@ -23,11 +43,10 @@ module RBS
         # @rbs returns self?
         def add_comment: (Prism::Comment comment) -> self?
 
-        # @rbs returns Array[[String, Prism::Comment]]
-        def lines: () -> Array[[ String, Prism::Comment ]]
+        # @rbs trim: bool -- `true` to trim the leading whitespaces
+        def content: (?trim: bool) -> String
 
-        # @rbs returns String
-        def content: () -> String
+        def lines: () -> Array[String]
       end
 
       attr_reader input: Array[Prism::Comment]
@@ -44,10 +63,62 @@ module RBS
 
       private
 
-      # @rbs result: ParsingResult
-      # @rbs block: ^(Array[Prism::Comment]) -> void
+      # Test if the comment is an annotation comment
+      #
+      # - Returns `nil` if the comment is not an annotation.
+      # - Returns `true` if the comment is `#::` or `#[` annotation. (Offset is `1`)
+      # - Returns Integer if the comment is `#@rbs` annotation. (Offset is the number of leading spaces including `#`)
+      #
+      # :: (Prism::Comment) -> (Integer | true | nil)
+      def annotation_comment?: (Prism::Comment) -> (Integer | true | nil)
+
+      # Split lines of comments in `result` into paragraphs
+      #
+      # A paragraph consists of:
+      #
+      # * An annotation syntax constructs -- starting with `@rbs` or `::`, or
+      # * A lines something else
+      #
+      # Yields an array of comments, and a boolean indicating if the comments may be an annotation.
+      #
+      # :: (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
+      def each_annotation_paragraph: (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
+
+      # The first annotation line is already detected and consumed.
+      # The annotation comment is already in `comments`.
+      #
+      # @rbs comments: Array[Prism::Comment] -- Annotation comments
+      # @rbs lines: Array[Prism::Comment] -- Lines to be consumed
+      # @rbs offset: Integer -- Offset of the first character of the first annotation comment from the `#` (>= 1)
+      # @rbs allow_empty_lines: bool -- `true` if empty line is allowed inside the annotation comments
+      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs returns void
-      def each_annotation_paragraph: (ParsingResult result) { (Array[Prism::Comment]) -> void } -> void
+      def yield_annotation: (Array[Prism::Comment] comments, Array[Prism::Comment] lines, Integer offset, allow_empty_lines: bool) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
+
+      # The first line is NOT consumed.
+      #
+      # The `comments` may be empty.
+      #
+      # @rbs comments: Array[Prism::Comment] -- Leading comments
+      # @rbs lines: Array[Prism::Comment] -- Lines to be consumed
+      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs returns void
+      def yield_paragraph: (Array[Prism::Comment] comments, Array[Prism::Comment] lines) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
+
+      # Consumes empty lines between annotation lines
+      #
+      # An empty line is already detected and consumed.
+      # The line is already removed from `lines` and put in `empty_comments`.
+      #
+      # Note that the arguments, `comments`, `empty_comments`, and `lines` are modified in place.
+      #
+      # @rbs comments: Array[Prism::Comment] -- Non empty annotation comments
+      # @rbs empty_comments: Array[Prism::Comment] -- Empty comments that may be part of the annotation
+      # @rbs lines: Array[Prism::Comment] -- Lines
+      # @rbs offset: Integer -- Offset of the first character of the annotation
+      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs returns void
+      def yield_empty_annotation: (Array[Prism::Comment] comments, Array[Prism::Comment] empty_comments, Array[Prism::Comment] lines, Integer offset) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
 
       class Tokenizer
         attr_reader scanner: StringScanner

--- a/sig/generated/rbs/inline/ast/comment_lines.rbs
+++ b/sig/generated/rbs/inline/ast/comment_lines.rbs
@@ -3,7 +3,7 @@
 module RBS
   module Inline
     module AST
-      # CommentLines represents consecutive comments
+      # CommentLines represents consecutive comments, providing a mapping from locations in `#string` to a pair of a comment and its offset
       #
       # The comments construct one String.
       #
@@ -15,13 +15,17 @@ module RBS
       # We want to get a String of comment1 and comment2, `"Hello\nWorld".
       # And want to translate a location in the string into the location in comment1 and comment2.
       class CommentLines
-        attr_reader comments: Array[[ Prism::Comment, Integer ]]
+        attr_reader comments: Array[Prism::Comment]
 
         # @rbs comments: Array[Prism::Comment]
         def initialize: (Array[Prism::Comment] comments) -> untyped
 
+        def lines: () -> Array[String]
+
         def string: () -> String
 
+        # Translates the cursor index of `#string` into the cursor index of a specific comment object
+        #
         # @rbs index: Integer
         # @rbs returns [Prism::Comment, Integer]?
         def comment_location: (Integer index) -> [ Prism::Comment, Integer ]?

--- a/test/rbs/inline/comment_lines_test.rb
+++ b/test/rbs/inline/comment_lines_test.rb
@@ -14,7 +14,8 @@ class RBS::Inline::AST::CommentLinesTest < Minitest::Test
       # Sample code
     RUBY
 
-    assert_equal "Sample code", lines.string
+    assert_equal " Sample code", lines.string
+    assert_equal ["# Sample code"], lines.lines
   end
 
   def test_string__multiline
@@ -25,12 +26,13 @@ class RBS::Inline::AST::CommentLinesTest < Minitest::Test
       # Another code:
     RUBY
 
-    assert_equal <<~TEXT.chop, lines.string
-      Sample code:
-        Hello World
+    assert_equal ["# Sample code:", "#   Hello World", "#", "# Another code:"], lines.lines
+    assert_equal <<TEXT.chop, lines.string
+ Sample code:
+   Hello World
 
-      Another code:
-    TEXT
+ Another code:
+TEXT
   end
 
   def test_comment_location
@@ -40,10 +42,10 @@ class RBS::Inline::AST::CommentLinesTest < Minitest::Test
     RUBY
     lines = AST::CommentLines.new(comments)
 
-    assert_equal [comments[0], 2], lines.comment_location(0)
-    assert_equal [comments[0], 14], lines.comment_location(12)
-    assert_equal [comments[1], 2], lines.comment_location(13)
-    assert_equal [comments[1], 15], lines.comment_location(26)
-    assert_nil lines.comment_location(27)
+    assert_equal [comments[0], 1], lines.comment_location(0)
+    assert_equal [comments[0], 14], lines.comment_location(13)
+    assert_equal [comments[1], 1], lines.comment_location(14)
+    assert_equal [comments[1], 15], lines.comment_location(28)
+    assert_nil lines.comment_location(29)
   end
 end


### PR DESCRIPTION
This PR fixes comment lines grouping to allow inserting empty lines inside `@rbs` or `@rbs!` annotation.

```rb
# @rbs!
#   type foo = Integer
#
#   type bar = String
```

The `@rbs!` annotation above didn't work well before this patch, because the third line is empty and the line has `0` leading spaces which leaves the `@rbs!` parsing.

This PR allows continuing the parsing of `@rbs!` and `@rbs` annotation with an empty line. The `#::` and `#[` annotation cannot continue after an empty line.