### PR TITLE
Use `@rbs x: T` syntax for parameter types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class Person
     "Person(name = #{name}, addresses = #{addresses.join(", ")})"
   end
 
-  # @rbs yields (String) -> void
+  # @rbs &block: (String) -> void
   def each_address(&block) #:: void
     addresses.each(&block)
   end

--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -317,6 +317,7 @@ module RBS
           "[" => :kLBRACKET,
           "]" => :kRBRACKET,
           "," => :kCOMMA,
+          "**" => :kSTAR2,
           "*" => :kSTAR,
           "--" => :kMINUS2,
           "<" => :kLT,
@@ -586,6 +587,9 @@ module RBS
           when tokenizer.type?(:kSTAR)
             tree << parse_splat_param_type(tokenizer)
             AST::Annotations::SplatParamType.new(tree, comments)
+          when tokenizer.type?(:kSTAR2)
+            tree << parse_splat_param_type(tokenizer)
+            AST::Annotations::DoubleSplatParamType.new(tree, comments)
           when tokenizer.type?(:kYIELDS)
             tree << parse_yields(tokenizer)
             AST::Annotations::Yields.new(tree, comments)
@@ -1020,7 +1024,7 @@ module RBS
       def parse_splat_param_type(tokenizer)
         tree = AST::Tree.new(:splat_param_type)
 
-        tokenizer.consume_token!(:kSTAR, tree: tree)
+        tokenizer.consume_token!(:kSTAR, :kSTAR2, tree: tree)
         tokenizer.consume_token(:tLVAR, tree: tree)
         tokenizer.consume_token(:kCOLON, tree: tree)
 

--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -188,7 +188,7 @@ module RBS
       # @rbs lines: Array[Prism::Comment] -- Lines to be consumed
       # @rbs offset: Integer -- Offset of the first character of the first annotation comment from the `#` (>= 1)
       # @rbs allow_empty_lines: bool -- `true` if empty line is allowed inside the annotation comments
-      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs &block: (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs return: void
       def yield_annotation(comments, lines, offset, allow_empty_lines:, &block)
         first_comment = lines.first
@@ -227,7 +227,7 @@ module RBS
       #
       # @rbs comments: Array[Prism::Comment] -- Leading comments
       # @rbs lines: Array[Prism::Comment] -- Lines to be consumed
-      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs &block: (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs return: void
       def yield_paragraph(comments, lines, &block)
         while first_comment = lines.first
@@ -261,7 +261,7 @@ module RBS
       # @rbs empty_comments: Array[Prism::Comment] -- Empty comments that may be part of the annotation
       # @rbs lines: Array[Prism::Comment] -- Lines
       # @rbs offset: Integer -- Offset of the first character of the annotation
-      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs &block: (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs return: void
       def yield_empty_annotation(comments, empty_comments, lines, offset, &block)
         first_comment = lines.first
@@ -306,12 +306,10 @@ module RBS
           "unchecked" => :kUNCHECKED,
           "self" => :kSELF,
           "skip" => :kSKIP,
-          "yields" => :kYIELDS,
         } #:: Hash[String, Symbol]
         KW_RE = /#{Regexp.union(KEYWORDS.keys)}\b/
 
         PUNCTS = {
-          "[optional]" => :kOPTIONAL,
           "::" => :kCOLON2,
           ":" => :kCOLON,
           "[" => :kLBRACKET,
@@ -325,6 +323,8 @@ module RBS
           "->" => :kARROW,
           "{" => :kLBRACE,
           "(" => :kLPAREN,
+          "&" => :kAMP,
+          "?" => :kQUESTION,
         } #:: Hash[String, Symbol]
         PUNCTS_RE = Regexp.union(PUNCTS.keys) #:: Regexp
 
@@ -554,7 +554,7 @@ module RBS
           when tokenizer.type?(:tLVAR, :tELVAR)
             tree << parse_var_decl(tokenizer)
             AST::Annotations::VarType.new(tree, comments)
-          when tokenizer.type?(:kSKIP, :kINHERITS, :kOVERRIDE, :kUSE, :kGENERIC, :kYIELDS) &&
+          when tokenizer.type?(:kSKIP, :kINHERITS, :kOVERRIDE, :kUSE, :kGENERIC) &&
             tokenizer.type2?(:kCOLON)
             tree << parse_var_decl(tokenizer)
             AST::Annotations::VarType.new(tree, comments)
@@ -590,9 +590,9 @@ module RBS
           when tokenizer.type?(:kSTAR2)
             tree << parse_splat_param_type(tokenizer)
             AST::Annotations::DoubleSplatParamType.new(tree, comments)
-          when tokenizer.type?(:kYIELDS)
-            tree << parse_yields(tokenizer)
-            AST::Annotations::Yields.new(tree, comments)
+          when tokenizer.type?(:kAMP)
+            tree << parse_block_type(tokenizer)
+            AST::Annotations::BlockType.new(tree, comments)
           when tokenizer.type?(:kLPAREN, :kARROW, :kLBRACE, :kLBRACKET)
             tree << parse_method_type_annotation(tokenizer)
             AST::Annotations::Method.new(tree, comments)
@@ -1038,11 +1038,14 @@ module RBS
       end
 
       #:: (Tokenizer) -> AST::Tree
-      def parse_yields(tokenizer)
-        tree = AST::Tree.new(:yields)
+      def parse_block_type(tokenizer)
+        tree = AST::Tree.new(:block_type)
 
-        tokenizer.consume_token!(:kYIELDS, tree: tree)
-        tokenizer.consume_token(:kOPTIONAL, tree: tree)
+        tokenizer.consume_token!(:kAMP, tree: tree)
+        tokenizer.consume_token(:tLVAR, tree: tree)
+        tokenizer.consume_token(:kCOLON, tree: tree)
+
+        tokenizer.consume_token(:kQUESTION, tree: tree)
 
         unless (string = tokenizer.skip_to_comment()).empty?
           tree << [:tBLOCKSTR, string]

--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -20,6 +20,7 @@ module RBS
         #          | Yields
         #          | Embedded
         #          | Method
+        #          | SplatParamType
         #        #  | Def
         #        #  | AttrReader | AttrWriter | AttrAccessor
         #        #  | Include | Extend | Prepend
@@ -71,6 +72,40 @@ module RBS
               true
             else
               false
+            end
+          end
+        end
+
+        class SplatParamType < Base
+          attr_reader :name #:: Symbol?
+
+          attr_reader :type #:: Types::t?
+
+          attr_reader :comment #:: String?
+
+          attr_reader :type_source #:: String
+
+          # @rbs override
+          def initialize(tree, source)
+            @tree = tree
+            @source = source
+
+            annotation = tree.nth_tree!(1)
+
+            if name = annotation.nth_token?(1)
+              @name = name[1].to_sym
+            end
+
+            if type = annotation.nth_type?(3)
+              @type = type
+              @type_source = type.location&.source || raise
+            else
+              @type = nil
+              @type_source = annotation.nth_tree!(3)&.to_s || raise
+            end
+
+            if comment = annotation.nth_tree(4)
+              @comment = comment.to_s
             end
           end
         end

--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -21,6 +21,7 @@ module RBS
         #          | Embedded
         #          | Method
         #          | SplatParamType
+        #          | DoubleSplatParamType
         #        #  | Def
         #        #  | AttrReader | AttrWriter | AttrAccessor
         #        #  | Include | Extend | Prepend
@@ -76,7 +77,7 @@ module RBS
           end
         end
 
-        class SplatParamType < Base
+        class SpecialVarTypeAnnotation < Base
           attr_reader :name #:: Symbol?
 
           attr_reader :type #:: Types::t?
@@ -108,6 +109,14 @@ module RBS
               @comment = comment.to_s
             end
           end
+        end
+
+        # `@rbs *x: T`
+        class SplatParamType < SpecialVarTypeAnnotation
+        end
+
+        # `@rbs` **x: T
+        class DoubleSplatParamType < SpecialVarTypeAnnotation
         end
 
         # `@rbs return: T`

--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -215,38 +215,16 @@ module RBS
                 end
 
                 if node.parameters.block
-                  if (block_name = node.parameters.block.name) && (var_type = var_type_hash[block_name])
-                    if var_type.is_a?(Types::Optional)
-                      optional = true
-                      var_type = var_type.type
-                    else
-                      optional = false
-                    end
-
-                    if var_type.is_a?(Types::Proc)
-                      block = Types::Block.new(type: var_type.type, self_type: var_type.self_type, required: !optional)
-                    end
-                  else
-                    block = Types::Block.new(
-                      type: Types::UntypedFunction.new(return_type: Types::Bases::Any.new(location: nil)),
-                      required: false,
-                      self_type: nil
-                    )
-                  end
-                end
-              end
-
-              if annotation = yields_annotation
-                case annotation.block_type
-                when Types::Block
-                  block = annotation.block_type
-                else
                   block = Types::Block.new(
                     type: Types::UntypedFunction.new(return_type: Types::Bases::Any.new(location: nil)),
-                    required: !annotation.optional,
+                    required: false,
                     self_type: nil
                   )
                 end
+              end
+
+              if type = block_type_annotation&.type
+                block = type
               end
 
               [
@@ -299,11 +277,11 @@ module RBS
             end
           end
 
-          def yields_annotation #:: AST::Annotations::Yields?
+          def block_type_annotation #:: AST::Annotations::BlockType?
             if comments
               comments.each_annotation.find do |annotation|
-                annotation.is_a?(AST::Annotations::Yields)
-              end #: AST::Annotations::Yields?
+                annotation.is_a?(AST::Annotations::BlockType)
+              end #: AST::Annotations::BlockType?
             end
           end
         end

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -296,7 +296,7 @@ module RBS
       end
 
       # @rbs new_visibility: RBS::AST::Members::visibility?
-      # @rbs block: ^() -> void
+      # @rbs &block: () -> void
       # @rbs return: void
       def push_visibility(new_visibility, &block)
         old_visibility = current_visibility

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -20,7 +20,7 @@ module RBS
         writer.output
       end
 
-      # @rbs lines: Array[String]
+      # @rbs *lines: String
       # @rbs return: void
       def header(*lines)
         lines.each do |line|

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -91,7 +91,7 @@ module RBS
       # @rbs lines: Array[Prism::Comment] -- Lines to be consumed
       # @rbs offset: Integer -- Offset of the first character of the first annotation comment from the `#` (>= 1)
       # @rbs allow_empty_lines: bool -- `true` if empty line is allowed inside the annotation comments
-      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs &block: (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs return: void
       def yield_annotation: (Array[Prism::Comment] comments, Array[Prism::Comment] lines, Integer offset, allow_empty_lines: bool) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
 
@@ -101,7 +101,7 @@ module RBS
       #
       # @rbs comments: Array[Prism::Comment] -- Leading comments
       # @rbs lines: Array[Prism::Comment] -- Lines to be consumed
-      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs &block: (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs return: void
       def yield_paragraph: (Array[Prism::Comment] comments, Array[Prism::Comment] lines) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
 
@@ -116,7 +116,7 @@ module RBS
       # @rbs empty_comments: Array[Prism::Comment] -- Empty comments that may be part of the annotation
       # @rbs lines: Array[Prism::Comment] -- Lines
       # @rbs offset: Integer -- Offset of the first character of the annotation
-      # @rbs yields (Array[Prism::Comment], bool is_annotation) -> void
+      # @rbs &block: (Array[Prism::Comment], bool is_annotation) -> void
       # @rbs return: void
       def yield_empty_annotation: (Array[Prism::Comment] comments, Array[Prism::Comment] empty_comments, Array[Prism::Comment] lines, Integer offset) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
 
@@ -330,7 +330,7 @@ module RBS
       # @rbs *types: Symbol
       # @rbs block: ^() -> AST::Tree
       # @rbs return: AST::Tree?
-      def parse_optional: (Tokenizer tokenizer, *Symbol types) { () -> AST::Tree } -> AST::Tree?
+      def parse_optional: (Tokenizer tokenizer, *Symbol types) ?{ (?) -> untyped } -> AST::Tree?
 
       # @rbs tokenizer: Tokenizer
       # @rbs return: AST::Tree
@@ -343,7 +343,7 @@ module RBS
       def parse_splat_param_type: (Tokenizer) -> AST::Tree
 
       # :: (Tokenizer) -> AST::Tree
-      def parse_yields: (Tokenizer) -> AST::Tree
+      def parse_block_type: (Tokenizer) -> AST::Tree
     end
   end
 end

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -176,33 +176,33 @@ module RBS
 
         # Consume given token type and inserts the token to the tree or `nil`
         #
-        # @rbs type: Array[Symbol]
+        # @rbs *types: Symbol
         # @rbs tree: AST::Tree
         # @rbs return: void
-        def consume_token: (*untyped types, tree: AST::Tree) -> void
+        def consume_token: (*Symbol types, tree: AST::Tree) -> void
 
         # Consume given token type and inserts the token to the tree or raise
         #
-        # @rbs types: Array[Symbol]
+        # @rbs *types: Symbol
         # @rbs tree: AST::Tree
         # @rbs return: void
         def consume_token!: (*Symbol types, tree: AST::Tree) -> void
 
         # Test if current token has specified `type`
         #
-        # @rbs type: Array[Symbol]
+        # @rbs types: *Symbol
         # @rbs return: bool
-        def type?: (*Symbol type) -> bool
+        def type?: (*untyped types) -> bool
 
         # Test if lookahead2 token have specified `type`
         #
-        # @rbs type: Symbol -- The type of the lookahead2 token
+        # @rbs *types: Symbol -- The type of the lookahead2 token
         # @rbs return: bool
-        def type2?: (*Symbol type) -> bool
+        def type2?: (*Symbol types) -> bool
 
         # Ensure current token is one of the specified in types
         #
-        # @rbs types: Array[Symbol]
+        # @rbs *types: Symbol
         # @rbs return: void
         def type!: (*Symbol types) -> void
 
@@ -327,7 +327,7 @@ module RBS
       # ```
       #
       # @rbs tokenizer: Tokenizer
-      # @rbs types: Array[Symbol]
+      # @rbs *types: Symbol
       # @rbs block: ^() -> AST::Tree
       # @rbs return: AST::Tree?
       def parse_optional: (Tokenizer tokenizer, *Symbol types) { () -> AST::Tree } -> AST::Tree?
@@ -338,6 +338,9 @@ module RBS
 
       # :: (Tokenizer) -> AST::Tree
       def parse_ivar_type: (Tokenizer) -> AST::Tree
+
+      # :: (Tokenizer) -> AST::Tree
+      def parse_splat_param_type: (Tokenizer) -> AST::Tree
 
       # :: (Tokenizer) -> AST::Tree
       def parse_yields: (Tokenizer) -> AST::Tree

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,7 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Yields | Embedded | Method | SplatParamType | DoubleSplatParamType
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType
 
         class Base
           attr_reader source: CommentLines
@@ -50,6 +50,20 @@ module RBS
 
         # `@rbs` **x: T
         class DoubleSplatParamType < SpecialVarTypeAnnotation
+        end
+
+        # `@rbs &block: METHOD-TYPE` or `@rbs &block: ? METHOD-TYPE`
+        class BlockType < Base
+          attr_reader name: Symbol?
+
+          attr_reader type: Types::Block?
+
+          attr_reader comment: String?
+
+          attr_reader type_source: String
+
+          # @rbs override
+          def initialize: ...
         end
 
         # `@rbs return: T`
@@ -104,28 +118,6 @@ module RBS
 
           # @rbs return: bool
           def complete?: () -> bool
-        end
-
-        # `# @rbs yields () -> void -- Comment`
-        class Yields < Base
-          # The type of block
-          #
-          # * Types::Block when syntactically correct input is given
-          # * String when syntax error is reported
-          # * `nil` when nothing is given
-          attr_reader block_type: Types::Block | String | nil
-
-          # The content of the comment or `nil`
-          attr_reader comment: String?
-
-          # If `[optional]` token is inserted just after `yields` token
-          #
-          # The Types::Block instance has correct `required` attribute based on the `[optional]` token.
-          # This is for the other cases, syntax error or omitted.
-          attr_reader optional: bool
-
-          # @rbs override
-          def initialize: ...
         end
 
         # `# @rbs %a{a} %a{a} ...`

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,7 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Yields | Embedded | Method
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Yields | Embedded | Method | SplatParamType
 
         class Base
           attr_reader source: CommentLines
@@ -29,6 +29,19 @@ module RBS
 
           # :: () -> bool
           def complete?: () -> bool
+        end
+
+        class SplatParamType < Base
+          attr_reader name: Symbol?
+
+          attr_reader type: Types::t?
+
+          attr_reader comment: String?
+
+          attr_reader type_source: String
+
+          # @rbs override
+          def initialize: ...
         end
 
         # `@rbs return: T`

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,7 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Yields | Embedded | Method | SplatParamType
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Yields | Embedded | Method | SplatParamType | DoubleSplatParamType
 
         class Base
           attr_reader source: CommentLines
@@ -31,7 +31,7 @@ module RBS
           def complete?: () -> bool
         end
 
-        class SplatParamType < Base
+        class SpecialVarTypeAnnotation < Base
           attr_reader name: Symbol?
 
           attr_reader type: Types::t?
@@ -42,6 +42,14 @@ module RBS
 
           # @rbs override
           def initialize: ...
+        end
+
+        # `@rbs *x: T`
+        class SplatParamType < SpecialVarTypeAnnotation
+        end
+
+        # `@rbs` **x: T
+        class DoubleSplatParamType < SpecialVarTypeAnnotation
         end
 
         # `@rbs return: T`

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -64,7 +64,7 @@ module RBS
 
           def override_annotation: () -> AST::Annotations::Override?
 
-          def yields_annotation: () -> AST::Annotations::Yields?
+          def block_type_annotation: () -> AST::Annotations::BlockType?
         end
 
         class RubyAlias < RubyBase

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -56,6 +56,8 @@ module RBS
 
           def splat_param_type_annotation: () -> Annotations::SplatParamType?
 
+          def double_splat_param_type_annotation: () -> Annotations::DoubleSplatParamType?
+
           def method_overloads: () -> Array[RBS::AST::Members::MethodDefinition::Overload]
 
           def method_annotations: () -> Array[RBS::AST::Annotation]

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -54,6 +54,8 @@ module RBS
 
           def var_type_hash: () -> Hash[Symbol, Types::t?]
 
+          def splat_param_type_annotation: () -> Annotations::SplatParamType?
+
           def method_overloads: () -> Array[RBS::AST::Members::MethodDefinition::Overload]
 
           def method_annotations: () -> Array[RBS::AST::Annotation]

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -89,7 +89,7 @@ module RBS
       def visit_call_node: ...
 
       # @rbs new_visibility: RBS::AST::Members::visibility?
-      # @rbs block: ^() -> void
+      # @rbs &block: () -> void
       # @rbs return: void
       def push_visibility: (RBS::AST::Members::visibility? new_visibility) { () -> void } -> void
 

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -14,7 +14,7 @@ module RBS
       # @rbs decls: Array[AST::Declarations::t]
       def self.write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls) -> untyped
 
-      # @rbs lines: Array[String]
+      # @rbs *lines: String
       # @rbs return: void
       def header: (*String lines) -> void
 

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -554,4 +554,34 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
       assert_equal "[A] { () -> A } -> Array[A]", annotation.method_type_source
     end
   end
+
+  def test_splat_param_type_annotation
+    annots = AnnotationParser.parse(parse_comments(<<~RUBY))
+      # @rbs *keys: Symbol -- the name of keys
+      # @rbs *: Integer
+      # @rbs *: Array[Strin
+      RUBY
+
+    annots[0].annotations[0].tap do |annotation|
+      assert_instance_of AST::Annotations::SplatParamType, annotation
+      assert_equal :keys, annotation.name
+      assert_equal "Symbol", annotation.type.to_s
+      assert_equal "Symbol", annotation.type_source
+      assert_equal "-- the name of keys", annotation.comment
+    end
+    annots[0].annotations[1].tap do |annotation|
+      assert_instance_of AST::Annotations::SplatParamType, annotation
+      assert_nil annotation.name
+      assert_equal "Integer", annotation.type.to_s
+      assert_equal "Integer", annotation.type_source
+      assert_nil annotation.comment
+    end
+    annots[0].annotations[2].tap do |annotation|
+      assert_instance_of AST::Annotations::SplatParamType, annotation
+      assert_nil annotation.name
+      assert_nil annotation.type
+      assert_equal "Array[Strin", annotation.type_source
+      assert_nil annotation.comment
+    end
+  end
 end

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -584,4 +584,34 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
       assert_nil annotation.comment
     end
   end
+
+  def test_double_splat_param_type_annotation
+    annots = AnnotationParser.parse(parse_comments(<<~RUBY))
+      # @rbs **attrs: Symbol -- the attributes
+      # @rbs **: Integer
+      # @rbs **: Array[Strin
+      RUBY
+
+    annots[0].annotations[0].tap do |annotation|
+      assert_instance_of AST::Annotations::DoubleSplatParamType, annotation
+      assert_equal :attrs, annotation.name
+      assert_equal "Symbol", annotation.type.to_s
+      assert_equal "Symbol", annotation.type_source
+      assert_equal "-- the attributes", annotation.comment
+    end
+    annots[0].annotations[1].tap do |annotation|
+      assert_instance_of AST::Annotations::DoubleSplatParamType, annotation
+      assert_nil annotation.name
+      assert_equal "Integer", annotation.type.to_s
+      assert_equal "Integer", annotation.type_source
+      assert_nil annotation.comment
+    end
+    annots[0].annotations[2].tap do |annotation|
+      assert_instance_of AST::Annotations::DoubleSplatParamType, annotation
+      assert_nil annotation.name
+      assert_nil annotation.type
+      assert_equal "Array[Strin", annotation.type_source
+      assert_nil annotation.comment
+    end
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -22,12 +22,11 @@ class RBS::Inline::WriterTest < Minitest::Test
         # @rbs x: Integer
         # @rbs foo: Symbol
         # @rbs bar: Integer?
-        # @rbs rest: Hash[Symbol, String?]
         # @rbs return: void
-        def f(x=0, foo:, bar: nil, **rest)
+        def f(x=0, foo:, bar: nil)
         end
 
-        def g(x=0, foo:, bar: nil, **rest)
+        def g(x=0, foo:, bar: nil)
         end
       end
     RUBY
@@ -42,11 +41,10 @@ class RBS::Inline::WriterTest < Minitest::Test
         # @rbs x: Integer
         # @rbs foo: Symbol
         # @rbs bar: Integer?
-        # @rbs rest: Hash[Symbol, String?]
         # @rbs return: void
-        def f: (?Integer x, foo: Symbol, ?bar: Integer?, **String? rest) -> void
+        def f: (?Integer x, foo: Symbol, ?bar: Integer?) -> void
 
-        def g: (?untyped x, foo: untyped, ?bar: untyped, **untyped rest) -> untyped
+        def g: (?untyped x, foo: untyped, ?bar: untyped) -> untyped
       end
     RBS
   end
@@ -85,6 +83,39 @@ class RBS::Inline::WriterTest < Minitest::Test
     RBS
   end
 
+  def test_method_type__double_splat
+    output = translate(<<~RUBY)
+      class Foo
+        def f(**x)
+        end
+
+        # @rbs **x: Integer
+        def g(**x)
+        end
+
+        def h(**)
+        end
+
+        # @rbs **: String
+        def i(**)
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class Foo
+        def f: (**untyped x) -> untyped
+
+        # @rbs **x: Integer
+        def g: (**Integer x) -> untyped
+
+        def h: (**untyped) -> untyped
+
+        # @rbs **: String
+        def i: (**String) -> untyped
+      end
+    RBS
+  end
 
   def test_method_type__return_assertion
     output = translate(<<~RUBY)

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -169,11 +169,11 @@ class RBS::Inline::WriterTest < Minitest::Test
   def test_method__block
     output = translate(<<~RUBY)
       class Foo
-        # @rbs block: ^(String) [self: Symbol] -> Integer
+        # @rbs &block: (String) [self: Symbol] -> Integer
         def foo(&block)
         end
 
-        # @rbs block: (^(String) [self: Symbol] -> Integer)?
+        # @rbs &block: ? (String) [self: Symbol] -> Integer
         def bar(&block)
         end
       end
@@ -181,10 +181,10 @@ class RBS::Inline::WriterTest < Minitest::Test
 
     assert_equal <<~RBS, output
       class Foo
-        # @rbs block: ^(String) [self: Symbol] -> Integer
+        # @rbs &block: (String) [self: Symbol] -> Integer
         def foo: () { (String) [self: Symbol] -> Integer } -> untyped
 
-        # @rbs block: (^(String) [self: Symbol] -> Integer)?
+        # @rbs &block: ? (String) [self: Symbol] -> Integer
         def bar: () ?{ (String) [self: Symbol] -> Integer } -> untyped
       end
     RBS
@@ -555,49 +555,14 @@ class RBS::Inline::WriterTest < Minitest::Test
   def test_method_type__block_yields_untyped
     output = translate(<<~RUBY)
       class Foo
-        # @rbs yields
         def foo(&)
-        end
-
-        # @rbs yields [optional] ()
-        def bar
         end
       end
     RUBY
 
     assert_equal <<~RBS, output
       class Foo
-        # @rbs yields
-        def foo: () { (?) -> untyped } -> untyped
-
-        # @rbs yields [optional] ()
-        def bar: () ?{ (?) -> untyped } -> untyped
-      end
-    RBS
-  end
-
-  def test_method_type__block_yields_typed
-    output = translate(<<~RUBY)
-      class Foo
-        # @rbs yields () -> void
-        def foo(&)
-        end
-
-        # @rbs yields [optional] () [self: String] -> Integer --
-        #   Something
-        def bar
-        end
-      end
-    RUBY
-
-    assert_equal <<~RBS, output
-      class Foo
-        # @rbs yields () -> void
-        def foo: () { () -> void } -> untyped
-
-        # @rbs yields [optional] () [self: String] -> Integer --
-        #   Something
-        def bar: () ?{ () [self: String] -> Integer } -> untyped
+        def foo: () ?{ (?) -> untyped } -> untyped
       end
     RBS
   end


### PR DESCRIPTION
This PR introduces `*x : T` and `**x: T` syntax for splat and double splat parameters. `&block: T` syntax is also added.

```rb
## For * params

# @rbs *keys: Symbol        => (*Symbol keys) -> ...
# @rbs *: untyped           => (*untyped) -> ...  (param names are optional)

## For **params

# @rbs **attrs: untyped     => (**untyped attrs) -> ...
# @rbs **: untyped          => (**untyped) -> ...  (param names are optional)

## For blocks

# @rbs &block: (Integer) -> void    => { (Integer) -> void }
# @rbs &: ? (untyped) -> void       => ?{ (untyped) -> void }  (Optional block, param names are optional)
```

Related to #9.