### PR TITLE
`#:` instead of `#::`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem "rake", "~> 13.2"
 
 gem "minitest", "~> 5.24"
 
-gem "steep", "~> 1.7.0", require: false
+gem "steep", "~> 1.8.0.dev", require: false
 gem "strscan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     rbs (3.5.1)
       logger
     securerandom (0.3.1)
-    steep (1.7.1)
+    steep (1.8.0.dev.1)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -82,7 +82,7 @@ DEPENDENCIES
   minitest (~> 5.24)
   rake (~> 13.2)
   rbs-inline!
-  steep (~> 1.7.0)
+  steep (~> 1.8.0.dev)
   strscan
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,15 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task default: :test
+
+namespace :rbs do
+  task :generate do
+    sh "rbs-inline --opt-out --output lib"
+  end
+
+  task :watch do
+    sh "fswatch -0 lib | xargs -n1 -0 rbs-inline --opt-out --output lib"
+  rescue Interrupt
+    # nop
+  end
+end

--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -20,12 +20,12 @@ module RBS
       # ```
       #
       class ParsingResult
-        attr_reader :comments #:: Array[Prism::Comment]
-        attr_reader :annotations #:: Array[AST::Annotations::t | AST::CommentLines]
-        attr_reader :first_comment_offset #:: Integer
+        attr_reader :comments #: Array[Prism::Comment]
+        attr_reader :annotations #: Array[AST::Annotations::t | AST::CommentLines]
+        attr_reader :first_comment_offset #: Integer
 
-        #:: () { (AST::Annotations::t) -> void } -> void
-        #:: () -> Enumerator[AST::Annotations::t, void]
+        #: () { (AST::Annotations::t) -> void } -> void
+        #: () -> Enumerator[AST::Annotations::t, void]
         def each_annotation(&block)
           if block
             annotations.each do |annot|
@@ -77,7 +77,7 @@ module RBS
         end
 
         # @rbs trim: bool -- `true` to trim the leading whitespaces
-        def content(trim: false) #:: String
+        def content(trim: false) #: String
           if trim
             leading_spaces = lines[0][/\A\s*/]
             offset = leading_spaces ? leading_spaces.length : 0
@@ -95,12 +95,12 @@ module RBS
           end
         end
 
-        def lines #:: Array[String]
+        def lines #: Array[String]
           comments.map { _1.location.slice[1...] || "" }
         end
       end
 
-      attr_reader :input #:: Array[Prism::Comment]
+      attr_reader :input #: Array[Prism::Comment]
 
       # @rbs input: Array[Prism::Comment]
       def initialize(input)
@@ -150,15 +150,15 @@ module RBS
       # Test if the comment is an annotation comment
       #
       # - Returns `nil` if the comment is not an annotation.
-      # - Returns `true` if the comment is `#::` or `#[` annotation. (Offset is `1`)
+      # - Returns `true` if the comment is `#:` or `#[` annotation. (Offset is `1`)
       # - Returns Integer if the comment is `#@rbs` annotation. (Offset is the number of leading spaces including `#`)
       #
-      #:: (Prism::Comment) -> (Integer | true | nil)
+      #: (Prism::Comment) -> (Integer | true | nil)
       def annotation_comment?(comment)
         line = comment.location.slice
 
         # No leading whitespace is allowed
-        return true if line.start_with?("#::")
+        return true if line.start_with?("#:")
         return true if line.start_with?("#[")
 
         if match = line.match(/\A#(\s*)@rbs(\b|!)/)
@@ -176,7 +176,7 @@ module RBS
       #
       # Yields an array of comments, and a boolean indicating if the comments may be an annotation.
       #
-      #:: (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
+      #: (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
       def each_annotation_paragraph(result, &block)
         yield_paragraph([], result.comments.dup, &block)
       end
@@ -306,7 +306,8 @@ module RBS
           "unchecked" => :kUNCHECKED,
           "self" => :kSELF,
           "skip" => :kSKIP,
-        } #:: Hash[String, Symbol]
+          "yields" => :kYIELDS,
+        } #: Hash[String, Symbol]
         KW_RE = /#{Regexp.union(KEYWORDS.keys)}\b/
 
         PUNCTS = {
@@ -325,16 +326,16 @@ module RBS
           "(" => :kLPAREN,
           "&" => :kAMP,
           "?" => :kQUESTION,
-        } #:: Hash[String, Symbol]
-        PUNCTS_RE = Regexp.union(PUNCTS.keys) #:: Regexp
+        } #: Hash[String, Symbol]
+        PUNCTS_RE = Regexp.union(PUNCTS.keys) #: Regexp
 
-        attr_reader :scanner #:: StringScanner
+        attr_reader :scanner #: StringScanner
 
         # Token that comes after the current position
-        attr_reader :lookahead1 #:: token?
+        attr_reader :lookahead1 #: token?
 
         # Token that comes after `lookahead1`
-        attr_reader :lookahead2 #:: token?
+        attr_reader :lookahead2 #: token?
 
         # Returns the current char position of the scanner
         #
@@ -345,14 +346,14 @@ module RBS
         #         ^    <= scanner.charpos
         # ```
         #
-        def current_position #:: Integer
+        def current_position #: Integer
           start = scanner.charpos
           start -= lookahead1[1].size if lookahead1
           start -= lookahead2[1].size if lookahead2
           start
         end
 
-        def lookaheads #:: Array[Symbol?]
+        def lookaheads #: Array[Symbol?]
           [lookahead1&.[](0), lookahead2&.[](0)]
         end
 
@@ -416,7 +417,7 @@ module RBS
         end
 
         # Returns true if the scanner cannot consume next token
-        def stuck? #:: bool
+        def stuck? #: bool
           lookahead1.nil? && lookahead2.nil?
         end
 
@@ -447,7 +448,7 @@ module RBS
           advance(tree)
         end
 
-        def rest #:: String
+        def rest #: String
           buf = +""
           buf << lookahead1[1] if lookahead1
           buf << lookahead2[1] if lookahead2
@@ -597,7 +598,7 @@ module RBS
             tree << parse_method_type_annotation(tokenizer)
             AST::Annotations::Method.new(tree, comments)
           end
-        when tokenizer.type?(:kCOLON2)
+        when tokenizer.type?(:kCOLON)
           tokenizer.advance(tree, eat: true)
           tree << parse_type_method_type(tokenizer, tree)
           AST::Annotations::Assertion.new(tree, comments)
@@ -1001,7 +1002,7 @@ module RBS
         tree
       end
 
-      #:: (Tokenizer) -> AST::Tree
+      #: (Tokenizer) -> AST::Tree
       def parse_ivar_type(tokenizer)
         tree = AST::Tree.new(:ivar_type)
 
@@ -1020,7 +1021,7 @@ module RBS
         tree
       end
 
-      #:: (Tokenizer) -> AST::Tree
+      #: (Tokenizer) -> AST::Tree
       def parse_splat_param_type(tokenizer)
         tree = AST::Tree.new(:splat_param_type)
 
@@ -1037,7 +1038,7 @@ module RBS
         tree
       end
 
-      #:: (Tokenizer) -> AST::Tree
+      #: (Tokenizer) -> AST::Tree
       def parse_block_type(tokenizer)
         tree = AST::Tree.new(:block_type)
 

--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -39,7 +39,7 @@ module RBS
         end
 
         # @rbs first_comment: Prism::Comment
-        def initialize(first_comment)
+        def initialize(first_comment) #: void
           @comments = [first_comment]
           @annotations = []
           content = first_comment.location.slice
@@ -103,7 +103,7 @@ module RBS
       attr_reader :input #: Array[Prism::Comment]
 
       # @rbs input: Array[Prism::Comment]
-      def initialize(input)
+      def initialize(input) #: void
         @input = input
       end
 
@@ -425,7 +425,7 @@ module RBS
         #
         # This method ensures the `current_position` will be the given `position`.
         #
-        # @rbs size: Integer -- The new position
+        # @rbs position: Integer -- The new position
         # @rbs tree: AST::Tree -- Tree to insert trivia tokens
         # @rbs return: void
         def reset(position, tree)
@@ -481,7 +481,7 @@ module RBS
 
         # Test if current token has specified `type`
         #
-        # @rbs types: *Symbol
+        # @rbs *types: Symbol
         # @rbs return: bool
         def type?(*types)
           types.any? { lookahead1 && lookahead1[0] == _1 }
@@ -823,7 +823,7 @@ module RBS
         tree
       end
 
-      # @rbs tokznier: Tokenizer
+      # @rbs tokenizer: Tokenizer
       # @rbs return: AST::Tree
       def parse_inherits(tokenizer)
         tree = AST::Tree.new(:rbs_inherits)
@@ -966,7 +966,7 @@ module RBS
       #
       # @rbs tokenizer: Tokenizer
       # @rbs *types: Symbol
-      # @rbs block: ^() -> AST::Tree
+      # @rbs &block: () -> AST::Tree
       # @rbs return: AST::Tree?
       def parse_optional(tokenizer, *types, &block)
         if tokenizer.type?(*types)

--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -26,10 +26,10 @@ module RBS
         #        #  | AttrReader | AttrWriter | AttrAccessor
         #        #  | Include | Extend | Prepend
         #        #  | Alias
- 
+
         class Base
-          attr_reader :source #:: CommentLines
-          attr_reader :tree #:: Tree
+          attr_reader :source #: CommentLines
+          attr_reader :tree #: Tree
 
           # @rbs tree: Tree
           # @rbs source: CommentLines
@@ -41,11 +41,11 @@ module RBS
         end
 
         class VarType < Base
-          attr_reader :name #:: Symbol
+          attr_reader :name #: Symbol
 
-          attr_reader :type #:: Types::t?
+          attr_reader :type #: Types::t?
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
           # @rbs override
           def initialize(tree, source)
@@ -67,7 +67,7 @@ module RBS
             end
           end
 
-          #:: () -> bool
+          #: () -> bool
           def complete?
             if name && type
               true
@@ -78,13 +78,13 @@ module RBS
         end
 
         class SpecialVarTypeAnnotation < Base
-          attr_reader :name #:: Symbol?
+          attr_reader :name #: Symbol?
 
-          attr_reader :type #:: Types::t?
+          attr_reader :type #: Types::t?
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
-          attr_reader :type_source #:: String
+          attr_reader :type_source #: String
 
           # @rbs override
           def initialize(tree, source)
@@ -168,9 +168,9 @@ module RBS
 
         # `@rbs return: T`
         class ReturnType < Base
-          attr_reader :type #:: Types::t?
+          attr_reader :type #: Types::t?
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
           # @rbs override
           def initialize(tree, source)
@@ -201,13 +201,13 @@ module RBS
         # `@rbs @foo: T` or `@rbs self.@foo: T`
         #
         class IvarType < Base
-          attr_reader :name #:: Symbol
+          attr_reader :name #: Symbol
 
-          attr_reader :type #:: Types::t?
+          attr_reader :type #: Types::t?
 
-          attr_reader :class_instance #:: bool
+          attr_reader :class_instance #: bool
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
           # @rbs override
           def initialize(tree, source)
@@ -225,10 +225,10 @@ module RBS
           end
         end
 
-        # `#:: TYPE`
+        # `#: TYPE`
         #
         class Assertion < Base
-          attr_reader :type #:: Types::t | MethodType | nil
+          attr_reader :type #: Types::t | MethodType | nil
 
           def initialize(tree, source)
             @source = source
@@ -248,7 +248,7 @@ module RBS
 
           # Returns a type if it's type
           #
-          def type? #:: Types::t?
+          def type? #: Types::t?
             case type
             when MethodType, nil
               nil
@@ -259,7 +259,7 @@ module RBS
 
           # Returns a method type if it's a method type
           #
-          def method_type? #:: MethodType?
+          def method_type? #: MethodType?
             case type
             when MethodType
               type
@@ -272,7 +272,7 @@ module RBS
         # `#[TYPE, ..., TYPE]`
         #
         class Application < Base
-          attr_reader :types #:: Array[Types::t]?
+          attr_reader :types #: Array[Types::t]?
 
           # @rbs override
           def initialize(tree, source)
@@ -303,7 +303,7 @@ module RBS
 
         # `# @rbs %a{a} %a{a} ...`
         class RBSAnnotation < Base
-          attr_reader :contents #:: Array[String]
+          attr_reader :contents #: Array[String]
 
           # @rbs override
           def initialize(tree, comments)
@@ -331,8 +331,8 @@ module RBS
         # `# @rbs inherits T`
         #
         class Inherits < Base
-          attr_reader :super_name #:: TypeName?
-          attr_reader :args #:: Array[Types::t]?
+          attr_reader :super_name #: TypeName?
+          attr_reader :args #: Array[Types::t]?
 
           # @rbs override
           def initialize(tree, source)
@@ -363,7 +363,7 @@ module RBS
 
         # `# @rbs use [USES]`
         class Use < Base
-          attr_reader :clauses #:: Array[RBS::AST::Directives::Use::clause]
+          attr_reader :clauses #: Array[RBS::AST::Directives::Use::clause]
 
           # @rbs override
           def initialize(tree, source)
@@ -415,9 +415,9 @@ module RBS
 
         # `# @rbs module-self [MODULE_SELF]`
         class ModuleSelf < Base
-          attr_reader :constraint #:: RBS::AST::Declarations::Module::Self?
+          attr_reader :constraint #: RBS::AST::Declarations::Module::Self?
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
           # @rbs override
           def initialize(tree, source)
@@ -453,9 +453,9 @@ module RBS
         class Generic < Base
           # TypeParam object or `nil` if syntax error
           #
-          attr_reader :type_param #:: RBS::AST::TypeParam?
+          attr_reader :type_param #: RBS::AST::TypeParam?
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
           # @rbs override
           def initialize(tree, source)
@@ -502,7 +502,7 @@ module RBS
 
         # `# @rbs!` annotation
         class Embedded < Base
-          attr_reader :content #:: String
+          attr_reader :content #: String
 
           # @rbs override
           def initialize(tree, source)
@@ -516,9 +516,9 @@ module RBS
         # `@rbs METHOD-TYPE``
         #
         class Method < Base
-          attr_reader :type #:: MethodType?
+          attr_reader :type #: MethodType?
 
-          attr_reader :method_type_source #:: String
+          attr_reader :method_type_source #: String
 
           # @rbs override
           def initialize(tree, source)

--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -121,13 +121,13 @@ module RBS
 
         # `@rbs &block: METHOD-TYPE` or `@rbs &block: ? METHOD-TYPE`
         class BlockType < Base
-          attr_reader :name #:: Symbol?
+          attr_reader :name #: Symbol?
 
-          attr_reader :type #:: Types::Block?
+          attr_reader :type #: Types::Block?
 
-          attr_reader :comment #:: String?
+          attr_reader :comment #: String?
 
-          attr_reader :type_source #:: String
+          attr_reader :type_source #: String
 
           # @rbs override
           def initialize(tree, source)
@@ -230,6 +230,7 @@ module RBS
         class Assertion < Base
           attr_reader :type #: Types::t | MethodType | nil
 
+          # @rbs override
           def initialize(tree, source)
             @source = source
             @tree = tree

--- a/lib/rbs/inline/ast/comment_lines.rb
+++ b/lib/rbs/inline/ast/comment_lines.rb
@@ -16,18 +16,18 @@ module RBS
       # And want to translate a location in the string into the location in comment1 and comment2.
       #
       class CommentLines
-        attr_reader :comments #:: Array[Prism::Comment]
+        attr_reader :comments #: Array[Prism::Comment]
 
         # @rbs comments: Array[Prism::Comment]
         def initialize(comments)
           @comments = comments
         end
 
-        def lines #:: Array[String]
+        def lines #: Array[String]
           comments.map {|comment| comment.location.slice }
         end
 
-        def string #:: String
+        def string #: String
           comments.map {|comment| comment.location.slice[1..] || "" }.join("\n")
         end
 

--- a/lib/rbs/inline/ast/comment_lines.rb
+++ b/lib/rbs/inline/ast/comment_lines.rb
@@ -19,7 +19,7 @@ module RBS
         attr_reader :comments #: Array[Prism::Comment]
 
         # @rbs comments: Array[Prism::Comment]
-        def initialize(comments)
+        def initialize(comments) #: void
           @comments = comments
         end
 

--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -169,7 +169,7 @@ module RBS
           # @rbs node: Prism::ConstantWriteNode
           # @rbs comments: AnnotationParser::ParsingResult?
           # @rbs assertion: Annotations::Assertion?
-          def initialize(node, comments, assertion)
+          def initialize(node, comments, assertion) #: void
             @node = node
             @comments = comments
             @assertion = assertion

--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -44,24 +44,24 @@ module RBS
         # @rbs generic NODE < Prism::Node
         class ModuleOrClass < Base
           # The node that represents the declaration
-          attr_reader :node #:: NODE
+          attr_reader :node #: NODE
 
           # Leading comment
-          attr_reader :comments #:: AnnotationParser::ParsingResult?
+          attr_reader :comments #: AnnotationParser::ParsingResult?
 
           # Members included in the declaration
-          attr_reader :members #:: Array[Members::t | t]
+          attr_reader :members #: Array[Members::t | t]
 
           # @rbs node: NODE
           # @rbs comments: AnnotationParser::ParsingResult?
-          def initialize(node, comments) #:: void
+          def initialize(node, comments) #: void
             @node = node
             @comments = comments
             @members = []
           end
 
           # Type parameters for the declaration
-          def type_params #:: Array[RBS::AST::TypeParam]
+          def type_params #: Array[RBS::AST::TypeParam]
             if comments = comments()
               comments.each_annotation.filter_map do |annotation|
                 if annotation.is_a?(Annotations::Generic)
@@ -73,7 +73,7 @@ module RBS
             end
           end
 
-          def start_line #:: Integer
+          def start_line #: Integer
             node.location.start_line
           end
         end
@@ -82,7 +82,7 @@ module RBS
           include ConstantUtil
 
           # Type application for super class
-          attr_reader :super_app #:: Annotations::Application?
+          attr_reader :super_app #: Annotations::Application?
 
           # @rbs node: Prism::ClassNode
           # @rbs comments: AnnotationParser::ParsingResult?
@@ -95,12 +95,12 @@ module RBS
           end
 
           # @rbs %a{pure}
-          def class_name #:: TypeName?
+          def class_name #: TypeName?
             type_name(node.constant_path)
           end
 
           # @rbs %a{pure}
-          def super_class #:: RBS::AST::Declarations::Class::Super?
+          def super_class #: RBS::AST::Declarations::Class::Super?
             if comments
               if inherits = comments.each_annotation.find {|a| a.is_a?(Annotations::Inherits) } #: Annotations::Inherits?
                 super_name = inherits.super_name
@@ -141,12 +141,12 @@ module RBS
           include ConstantUtil
 
           # @rbs %a{pure}
-          def module_name #:: TypeName?
+          def module_name #: TypeName?
             type_name(node.constant_path)
           end
 
           # @rbs %a{pure}
-          def module_selfs #:: Array[Annotations::ModuleSelf]
+          def module_selfs #: Array[Annotations::ModuleSelf]
             if comments
               comments.each_annotation.filter_map do |ann|
                 if ann.is_a?(AST::Annotations::ModuleSelf)
@@ -162,9 +162,9 @@ module RBS
         class ConstantDecl < Base
           include ConstantUtil
 
-          attr_reader :node #:: Prism::ConstantWriteNode
-          attr_reader :comments #:: AnnotationParser::ParsingResult?
-          attr_reader :assertion #:: Annotations::Assertion?
+          attr_reader :node #: Prism::ConstantWriteNode
+          attr_reader :comments #: AnnotationParser::ParsingResult?
+          attr_reader :assertion #: Annotations::Assertion?
 
           # @rbs node: Prism::ConstantWriteNode
           # @rbs comments: AnnotationParser::ParsingResult?
@@ -223,7 +223,7 @@ module RBS
             TypeName.new(name: node.name, namespace: Namespace.empty)
           end
 
-          def start_line #:: Integer
+          def start_line #: Integer
             node.location.start_line
           end
         end

--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -292,7 +292,7 @@ module RBS
 
           # @rbs node: Prism::AliasMethodNode
           # @rbs comments: AnnotationParser::ParsingResult?
-          def initialize(node, comments)
+          def initialize(node, comments) #: void
             @node = node
             @comments = comments
 

--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -12,14 +12,14 @@ module RBS
         #   type t = ruby | rbs
 
         class Base
-          attr_reader :location #:: Prism::Location
+          attr_reader :location #: Prism::Location
 
           # @rbs location: Prism::Location
-          def initialize(location) #:: void
+          def initialize(location) #: void
             @location = location
           end
 
-          def start_line #:: Integer
+          def start_line #: Integer
             location.start_line
           end
         end
@@ -28,8 +28,8 @@ module RBS
         end
 
         class RubyDef < RubyBase
-          attr_reader :node #:: Prism::DefNode
-          attr_reader :comments #:: AnnotationParser::ParsingResult?
+          attr_reader :node #: Prism::DefNode
+          attr_reader :comments #: AnnotationParser::ParsingResult?
 
           # The visibility directly attached to the `def` node
           #
@@ -39,15 +39,15 @@ module RBS
           # def foo() end            # <= nil
           # private def foo() end    # <= :private
           # ```
-          attr_reader :visibility #:: RBS::AST::Members::visibility?
+          attr_reader :visibility #: RBS::AST::Members::visibility?
 
-          attr_reader :assertion #:: Annotations::Assertion?
+          attr_reader :assertion #: Annotations::Assertion?
 
           # @rbs node: Prism::DefNode
           # @rbs comments: AnnotationParser::ParsingResult?
           # @rbs visibility: RBS::AST::Members::visibility?
           # @rbs assertion: Annotations::Assertion?
-          def initialize(node, comments, visibility, assertion) #:: void
+          def initialize(node, comments, visibility, assertion) #: void
             @node = node
             @comments = comments
             @visibility = visibility
@@ -57,11 +57,11 @@ module RBS
           end
 
           # Returns the name of the method
-          def method_name #:: Symbol
+          def method_name #: Symbol
             node.name
           end
 
-          def annotated_method_types #:: Array[MethodType]
+          def annotated_method_types #: Array[MethodType]
             if comments
               comments.each_annotation.filter_map do |annotation|
                 case annotation
@@ -80,7 +80,7 @@ module RBS
             end
           end
 
-          def return_type #:: Types::t?
+          def return_type #: Types::t?
             if assertion
               if assertion.type?
                 return assertion.type?
@@ -94,7 +94,7 @@ module RBS
             end
           end
 
-          def var_type_hash #:: Hash[Symbol, Types::t?]
+          def var_type_hash #: Hash[Symbol, Types::t?]
             types = {} #: Hash[Symbol, Types::t?]
 
             if comments
@@ -113,7 +113,7 @@ module RBS
             types
           end
 
-          def splat_param_type_annotation #:: Annotations::SplatParamType?
+          def splat_param_type_annotation #: Annotations::SplatParamType?
             if comments
               comments.each_annotation.find do |annotation|
                 annotation.is_a?(Annotations::SplatParamType)
@@ -121,7 +121,7 @@ module RBS
             end
           end
 
-          def double_splat_param_type_annotation #:: Annotations::DoubleSplatParamType?
+          def double_splat_param_type_annotation #: Annotations::DoubleSplatParamType?
             if comments
               comments.each_annotation.find do |annotation|
                 annotation.is_a?(Annotations::DoubleSplatParamType)
@@ -129,7 +129,7 @@ module RBS
             end
           end
 
-          def method_overloads #:: Array[RBS::AST::Members::MethodDefinition::Overload]
+          def method_overloads #: Array[RBS::AST::Members::MethodDefinition::Overload]
             case
             when (method_types = annotated_method_types).any?
               method_types.map do |method_type|
@@ -250,7 +250,7 @@ module RBS
             end
           end
 
-          def method_annotations #:: Array[RBS::AST::Annotation]
+          def method_annotations #: Array[RBS::AST::Annotation]
             if comments
               comments.each_annotation.flat_map do |annotation|
                 if annotation.is_a?(AST::Annotations::RBSAnnotation)
@@ -269,7 +269,7 @@ module RBS
             end
           end
 
-          def override_annotation #:: AST::Annotations::Override?
+          def override_annotation #: AST::Annotations::Override?
             if comments
               comments.each_annotation.find do |annotation|
                 annotation.is_a?(AST::Annotations::Override)
@@ -277,7 +277,7 @@ module RBS
             end
           end
 
-          def block_type_annotation #:: AST::Annotations::BlockType?
+          def block_type_annotation #: AST::Annotations::BlockType?
             if comments
               comments.each_annotation.find do |annotation|
                 annotation.is_a?(AST::Annotations::BlockType)
@@ -287,8 +287,8 @@ module RBS
         end
 
         class RubyAlias < RubyBase
-          attr_reader :node #:: Prism::AliasMethodNode
-          attr_reader :comments #:: AnnotationParser::ParsingResult?
+          attr_reader :node #: Prism::AliasMethodNode
+          attr_reader :comments #: AnnotationParser::ParsingResult?
 
           # @rbs node: Prism::AliasMethodNode
           # @rbs comments: AnnotationParser::ParsingResult?
@@ -318,13 +318,13 @@ module RBS
           include Declarations::ConstantUtil
 
           # CallNode that calls `include`, `prepend`, and `extend` method
-          attr_reader :node #:: Prism::CallNode
+          attr_reader :node #: Prism::CallNode
 
           # Comments attached to the call node
-          attr_reader :comments #:: AnnotationParser::ParsingResult?
+          attr_reader :comments #: AnnotationParser::ParsingResult?
 
           # Possible following type application annotation
-          attr_reader :application #:: Annotations::Application?
+          attr_reader :application #: Annotations::Application?
 
           # @rbs node: Prism::CallNode
           # @rbs comments: AnnotationParser::ParsingResult?
@@ -387,9 +387,9 @@ module RBS
         end
 
         class RubyAttr < RubyBase
-          attr_reader :node #:: Prism::CallNode
-          attr_reader :comments #:: AnnotationParser::ParsingResult?
-          attr_reader :assertion #:: Annotations::Assertion?
+          attr_reader :node #: Prism::CallNode
+          attr_reader :comments #: AnnotationParser::ParsingResult?
+          attr_reader :assertion #: Annotations::Assertion?
 
           # @rbs node: Prism::CallNode
           # @rbs comments: AnnotationParser::ParsingResult?
@@ -451,7 +451,7 @@ module RBS
           #
           # Returns `untyped` when not annotated.
           #
-          def attribute_type #:: Types::t
+          def attribute_type #: Types::t
             type = assertion&.type
             raise if type.is_a?(MethodType)
 
@@ -462,10 +462,10 @@ module RBS
         # `private` call without arguments
         #
         class RubyPrivate < RubyBase
-          attr_reader :node #:: Prism::CallNode
+          attr_reader :node #: Prism::CallNode
 
           # @rbs node: Prism::CallNode
-          def initialize(node) #:: void
+          def initialize(node) #: void
             super(node.location)
             @node = node
           end
@@ -474,10 +474,10 @@ module RBS
         # `public` call without arguments
         #
         class RubyPublic < RubyBase
-          attr_reader :node #:: Prism::CallNode
+          attr_reader :node #: Prism::CallNode
 
           # @rbs node: Prism::CallNode
-          def initialize(node) #:: void
+          def initialize(node) #: void
             super(node.location)
             @node = node
           end
@@ -487,20 +487,20 @@ module RBS
         end
 
         class RBSIvar < RBSBase
-          attr_reader :annotation #:: Annotations::IvarType
+          attr_reader :annotation #: Annotations::IvarType
 
-          attr_reader :comment #:: AnnotationParser::ParsingResult
+          attr_reader :comment #: AnnotationParser::ParsingResult
 
           # @rbs comment: AnnotationParser::ParsingResult
           # @rbs annotation: Annotations::IvarType
-          def initialize(comment, annotation) #:: void
+          def initialize(comment, annotation) #: void
             @comment = comment
             @annotation = annotation
 
             super(comment.comments[0].location)
           end
 
-          def rbs #:: RBS::AST::Members::InstanceVariable | RBS::AST::Members::ClassInstanceVariable | nil
+          def rbs #: RBS::AST::Members::InstanceVariable | RBS::AST::Members::ClassInstanceVariable | nil
             if annotation.type
               if annotation.comment
                 string = annotation.comment.delete_prefix("--").lstrip
@@ -527,13 +527,13 @@ module RBS
         end
 
         class RBSEmbedded < RBSBase
-          attr_reader :annotation #:: Annotations::Embedded
+          attr_reader :annotation #: Annotations::Embedded
 
-          attr_reader :comment #:: AnnotationParser::ParsingResult
+          attr_reader :comment #: AnnotationParser::ParsingResult
 
           # @rbs comment: AnnotationParser::ParsingResult
           # @rbs annotation: Annotations::Embedded
-          def initialize(comment, annotation) #:: void
+          def initialize(comment, annotation) #: void
             @comment = comment
             @annotation = annotation
 
@@ -544,7 +544,7 @@ module RBS
           #
           # Returns `RBS::ParsingError` when the `content` has syntax error.
           #
-          def members #:: Array[RBS::AST::Members::t | RBS::AST::Declarations::t] | RBS::ParsingError
+          def members #: Array[RBS::AST::Members::t | RBS::AST::Declarations::t] | RBS::ParsingError
             source = <<~RBS
               module EmbeddedModuleTest
                 #{annotation.content}

--- a/lib/rbs/inline/ast/tree.rb
+++ b/lib/rbs/inline/ast/tree.rb
@@ -16,7 +16,7 @@ module RBS
         attr_reader :non_trivia_trees #: Array[tree]
 
         # @rbs type: Symbol
-        def initialize(type)
+        def initialize(type) #: void
           @type = type
           @trees = []
           @non_trivia_trees = []

--- a/lib/rbs/inline/ast/tree.rb
+++ b/lib/rbs/inline/ast/tree.rb
@@ -9,11 +9,11 @@ module RBS
         #
         #   type tree = token | Tree | Types::t | MethodType | nil
 
-        attr_reader :trees #:: Array[tree]
-        attr_reader :type #:: Symbol
+        attr_reader :trees #: Array[tree]
+        attr_reader :type #: Symbol
 
         # Children but without `tWHITESPACE` tokens
-        attr_reader :non_trivia_trees #:: Array[tree]
+        attr_reader :non_trivia_trees #: Array[tree]
 
         # @rbs type: Symbol
         def initialize(type)
@@ -33,7 +33,7 @@ module RBS
         end
 
         # Returns the source code associated to the tree
-        def to_s #:: String
+        def to_s #: String
           buf = +""
 
           trees.each do |tree|

--- a/lib/rbs/inline/cli.rb
+++ b/lib/rbs/inline/cli.rb
@@ -17,22 +17,22 @@ module RBS
       #
       #
       class PathCalculator
-        attr_reader :pwd #:: Pathname
+        attr_reader :pwd #: Pathname
 
-        attr_reader :base_paths #:: Array[Pathname]
+        attr_reader :base_paths #: Array[Pathname]
 
-        attr_reader :output_path #:: Pathname
+        attr_reader :output_path #: Pathname
 
         # @rbs pwd: Pathname
         # @rbs base_paths: Array[Pathname]
         # @rbs output_path: Pathname
-        def initialize(pwd, base_paths, output_path) #:: void
+        def initialize(pwd, base_paths, output_path) #: void
           @pwd = pwd
           @base_paths = base_paths
           @output_path = output_path
         end
 
-        #:: (Pathname) -> Pathname?
+        #: (Pathname) -> Pathname?
         def calculate(path)
           path = pwd + path if path.relative?
           path = path.cleanpath
@@ -55,12 +55,12 @@ module RBS
         end
       end
 
-      attr_reader :stdout, :stderr #:: IO
-      attr_reader :logger #:: Logger
+      attr_reader :stdout, :stderr #: IO
+      attr_reader :logger #: Logger
 
       # @rbs stdout: IO
       # @rbs stderr: IO
-      def initialize(stdout: STDOUT, stderr: STDERR) #:: void
+      def initialize(stdout: STDOUT, stderr: STDERR) #: void
         @stdout = stdout
         @stderr = stderr
         @logger = Logger.new(stderr)

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -7,11 +7,11 @@ module RBS
     class Parser < Prism::Visitor
       # The top level declarations
       #
-      attr_reader :decls #:: Array[AST::Declarations::t]
+      attr_reader :decls #: Array[AST::Declarations::t]
 
       # The surrounding declarations
       #
-      attr_reader :surrounding_decls #:: Array[AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl]
+      attr_reader :surrounding_decls #: Array[AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl]
 
       # ParsingResult associated with the line number at the end
       #
@@ -23,16 +23,16 @@ module RBS
       # > [!IMPORTANT]
       # > The values will be removed during parsing.
       #
-      attr_reader :comments #:: Hash[Integer, AnnotationParser::ParsingResult]
+      attr_reader :comments #: Hash[Integer, AnnotationParser::ParsingResult]
 
       # The current visibility applied to single `def` node
       #
       # Assuming it's directly inside `private` or `public` calls.
       # `nil` when the `def` node is not inside `private` or `public` calls.
       #
-      attr_reader :current_visibility #:: RBS::AST::Members::visibility?
+      attr_reader :current_visibility #: RBS::AST::Members::visibility?
 
-      def initialize() #:: void
+      def initialize() #: void
         @decls = []
         @surrounding_decls = []
         @comments = {}
@@ -86,8 +86,8 @@ module RBS
         current_class_module_decl or raise
       end
 
-      #:: (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
-      #:: (AST::Declarations::ConstantDecl) -> void
+      #: (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
+      #: (AST::Declarations::ConstantDecl) -> void
       def push_class_module_decl(decl)
         if current = current_class_module_decl
           current.members << decl
@@ -114,7 +114,7 @@ module RBS
       # @rbs members: Array[AST::Members::t | AST::Declarations::t] --
       #   The destination.
       #   The method doesn't insert declarations, but have it to please type checker.
-      def load_inner_annotations(start_line, end_line, members) #:: void
+      def load_inner_annotations(start_line, end_line, members) #: void
         comments = inner_annotations(start_line, end_line)
 
         comments.each do |comment|
@@ -191,7 +191,7 @@ module RBS
       #
       # @rbs start_line: Integer
       # @rbs end_line: Integer
-      def inner_annotations(start_line, end_line) #:: Array[AnnotationParser::ParsingResult]
+      def inner_annotations(start_line, end_line) #: Array[AnnotationParser::ParsingResult]
         annotations = comments.each_value.select do |annotation|
           range = annotation.line_range
           start_line < range.begin && range.end < end_line

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -7,14 +7,14 @@ module RBS
       attr_reader :writer #: RBS::Writer
 
       # @rbs buffer: String
-      def initialize(buffer = +"")
+      def initialize(buffer = +"") #: void
         @output = buffer
         @writer = RBS::Writer.new(out: StringIO.new(buffer))
       end
 
       # @rbs uses: Array[AST::Annotations::Use]
       # @rbs decls: Array[AST::Declarations::t]
-      def self.write(uses, decls)
+      def self.write(uses, decls) #: void
         writer = Writer.new()
         writer.write(uses, decls)
         writer.output

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -3,8 +3,8 @@
 module RBS
   module Inline
     class Writer
-      attr_reader :output #:: String
-      attr_reader :writer #:: RBS::Writer
+      attr_reader :output #: String
+      attr_reader :writer #: RBS::Writer
 
       # @rbs buffer: String
       def initialize(buffer = +"")

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -25,8 +25,8 @@ module RBS
 
         attr_reader first_comment_offset: Integer
 
-        # :: () { (AST::Annotations::t) -> void } -> void
-        # :: () -> Enumerator[AST::Annotations::t, void]
+        # : () { (AST::Annotations::t) -> void } -> void
+        # : () -> Enumerator[AST::Annotations::t, void]
         def each_annotation: () { (AST::Annotations::t) -> void } -> void
                            | () -> Enumerator[AST::Annotations::t, void]
 
@@ -66,10 +66,10 @@ module RBS
       # Test if the comment is an annotation comment
       #
       # - Returns `nil` if the comment is not an annotation.
-      # - Returns `true` if the comment is `#::` or `#[` annotation. (Offset is `1`)
+      # - Returns `true` if the comment is `#:` or `#[` annotation. (Offset is `1`)
       # - Returns Integer if the comment is `#@rbs` annotation. (Offset is the number of leading spaces including `#`)
       #
-      # :: (Prism::Comment) -> (Integer | true | nil)
+      # : (Prism::Comment) -> (Integer | true | nil)
       def annotation_comment?: (Prism::Comment) -> (Integer | true | nil)
 
       # Split lines of comments in `result` into paragraphs
@@ -81,7 +81,7 @@ module RBS
       #
       # Yields an array of comments, and a boolean indicating if the comments may be an annotation.
       #
-      # :: (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
+      # : (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
       def each_annotation_paragraph: (ParsingResult) { (Array[Prism::Comment], bool is_annotation) -> void } -> void
 
       # The first annotation line is already detected and consumed.
@@ -336,13 +336,13 @@ module RBS
       # @rbs return: AST::Tree
       def parse_generic: (Tokenizer tokenizer) -> AST::Tree
 
-      # :: (Tokenizer) -> AST::Tree
+      # : (Tokenizer) -> AST::Tree
       def parse_ivar_type: (Tokenizer) -> AST::Tree
 
-      # :: (Tokenizer) -> AST::Tree
+      # : (Tokenizer) -> AST::Tree
       def parse_splat_param_type: (Tokenizer) -> AST::Tree
 
-      # :: (Tokenizer) -> AST::Tree
+      # : (Tokenizer) -> AST::Tree
       def parse_block_type: (Tokenizer) -> AST::Tree
     end
   end

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -31,7 +31,7 @@ module RBS
                            | () -> Enumerator[AST::Annotations::t, void]
 
         # @rbs first_comment: Prism::Comment
-        def initialize: (Prism::Comment first_comment) -> untyped
+        def initialize: (Prism::Comment first_comment) -> void
 
         # @rbs return: Range[Integer]
         def line_range: () -> Range[Integer]
@@ -52,7 +52,7 @@ module RBS
       attr_reader input: Array[Prism::Comment]
 
       # @rbs input: Array[Prism::Comment]
-      def initialize: (Array[Prism::Comment] input) -> untyped
+      def initialize: (Array[Prism::Comment] input) -> void
 
       # @rbs input: Array[Prism::Comment]
       # @rbs return: Array[ParsingResult]
@@ -167,10 +167,10 @@ module RBS
         #
         # This method ensures the `current_position` will be the given `position`.
         #
-        # @rbs size: Integer -- The new position
+        # @rbs position: Integer -- The new position
         # @rbs tree: AST::Tree -- Tree to insert trivia tokens
         # @rbs return: void
-        def reset: (untyped position, AST::Tree tree) -> void
+        def reset: (Integer position, AST::Tree tree) -> void
 
         def rest: () -> String
 
@@ -190,9 +190,9 @@ module RBS
 
         # Test if current token has specified `type`
         #
-        # @rbs types: *Symbol
+        # @rbs *types: Symbol
         # @rbs return: bool
-        def type?: (*untyped types) -> bool
+        def type?: (*Symbol types) -> bool
 
         # Test if lookahead2 token have specified `type`
         #
@@ -283,9 +283,9 @@ module RBS
       # @rbs return: AST::Tree
       def parse_rbs_annotation: (Tokenizer tokenizer) -> AST::Tree
 
-      # @rbs tokznier: Tokenizer
+      # @rbs tokenizer: Tokenizer
       # @rbs return: AST::Tree
-      def parse_inherits: (untyped tokenizer) -> AST::Tree
+      def parse_inherits: (Tokenizer tokenizer) -> AST::Tree
 
       # Parse `@rbs override` annotation
       #
@@ -328,9 +328,9 @@ module RBS
       #
       # @rbs tokenizer: Tokenizer
       # @rbs *types: Symbol
-      # @rbs block: ^() -> AST::Tree
+      # @rbs &block: () -> AST::Tree
       # @rbs return: AST::Tree?
-      def parse_optional: (Tokenizer tokenizer, *Symbol types) ?{ (?) -> untyped } -> AST::Tree?
+      def parse_optional: (Tokenizer tokenizer, *Symbol types) { () -> AST::Tree } -> AST::Tree?
 
       # @rbs tokenizer: Tokenizer
       # @rbs return: AST::Tree

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -54,13 +54,13 @@ module RBS
 
         # `@rbs &block: METHOD-TYPE` or `@rbs &block: ? METHOD-TYPE`
         class BlockType < Base
-          attr_reader name: untyped
+          attr_reader name: Symbol?
 
-          attr_reader type: untyped
+          attr_reader type: Types::Block?
 
-          attr_reader comment: untyped
+          attr_reader comment: String?
 
-          attr_reader type_source: untyped
+          attr_reader type_source: String
 
           # @rbs override
           def initialize: ...
@@ -97,7 +97,8 @@ module RBS
         class Assertion < Base
           attr_reader type: Types::t | MethodType | nil
 
-          def initialize: (untyped tree, untyped source) -> untyped
+          # @rbs override
+          def initialize: ...
 
           # @rbs return: bool
           def complete?: () -> bool

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -27,7 +27,7 @@ module RBS
           # @rbs override
           def initialize: ...
 
-          # :: () -> bool
+          # : () -> bool
           def complete?: () -> bool
         end
 
@@ -54,13 +54,13 @@ module RBS
 
         # `@rbs &block: METHOD-TYPE` or `@rbs &block: ? METHOD-TYPE`
         class BlockType < Base
-          attr_reader name: Symbol?
+          attr_reader name: untyped
 
-          attr_reader type: Types::Block?
+          attr_reader type: untyped
 
-          attr_reader comment: String?
+          attr_reader comment: untyped
 
-          attr_reader type_source: String
+          attr_reader type_source: untyped
 
           # @rbs override
           def initialize: ...
@@ -93,7 +93,7 @@ module RBS
           def initialize: ...
         end
 
-        # `#:: TYPE`
+        # `#: TYPE`
         class Assertion < Base
           attr_reader type: Types::t | MethodType | nil
 

--- a/sig/generated/rbs/inline/ast/comment_lines.rbs
+++ b/sig/generated/rbs/inline/ast/comment_lines.rbs
@@ -18,7 +18,7 @@ module RBS
         attr_reader comments: Array[Prism::Comment]
 
         # @rbs comments: Array[Prism::Comment]
-        def initialize: (Array[Prism::Comment] comments) -> untyped
+        def initialize: (Array[Prism::Comment] comments) -> void
 
         def lines: () -> Array[String]
 

--- a/sig/generated/rbs/inline/ast/declarations.rbs
+++ b/sig/generated/rbs/inline/ast/declarations.rbs
@@ -91,7 +91,7 @@ module RBS
           # @rbs node: Prism::ConstantWriteNode
           # @rbs comments: AnnotationParser::ParsingResult?
           # @rbs assertion: Annotations::Assertion?
-          def initialize: (Prism::ConstantWriteNode node, AnnotationParser::ParsingResult? comments, Annotations::Assertion? assertion) -> untyped
+          def initialize: (Prism::ConstantWriteNode node, AnnotationParser::ParsingResult? comments, Annotations::Assertion? assertion) -> void
 
           # @rbs %a{pure}
           # @rbs return: Types::t

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -74,7 +74,7 @@ module RBS
 
           # @rbs node: Prism::AliasMethodNode
           # @rbs comments: AnnotationParser::ParsingResult?
-          def initialize: (Prism::AliasMethodNode node, AnnotationParser::ParsingResult? comments) -> untyped
+          def initialize: (Prism::AliasMethodNode node, AnnotationParser::ParsingResult? comments) -> void
 
           # @rbs return: Symbol -- the name of *old* method
           def old_name: () -> Symbol

--- a/sig/generated/rbs/inline/ast/tree.rbs
+++ b/sig/generated/rbs/inline/ast/tree.rbs
@@ -16,7 +16,7 @@ module RBS
         attr_reader non_trivia_trees: Array[tree]
 
         # @rbs type: Symbol
-        def initialize: (Symbol type) -> untyped
+        def initialize: (Symbol type) -> void
 
         # @rbs tok: tree
         # @rbs return: self

--- a/sig/generated/rbs/inline/cli.rbs
+++ b/sig/generated/rbs/inline/cli.rbs
@@ -25,7 +25,7 @@ module RBS
         # @rbs output_path: Pathname
         def initialize: (Pathname pwd, Array[Pathname] base_paths, Pathname output_path) -> void
 
-        # :: (Pathname) -> Pathname?
+        # : (Pathname) -> Pathname?
         def calculate: (Pathname) -> Pathname?
 
         # @rbs path: Pathname

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -41,8 +41,8 @@ module RBS
       # @rbs return: AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl
       def current_class_module_decl!: () -> (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl)
 
-      # :: (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
-      # :: (AST::Declarations::ConstantDecl) -> void
+      # : (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
+      # : (AST::Declarations::ConstantDecl) -> void
       def push_class_module_decl: (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
                                 | (AST::Declarations::ConstantDecl) -> void
 

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -8,11 +8,11 @@ module RBS
       attr_reader writer: RBS::Writer
 
       # @rbs buffer: String
-      def initialize: (?String buffer) -> untyped
+      def initialize: (?String buffer) -> void
 
       # @rbs uses: Array[AST::Annotations::Use]
       # @rbs decls: Array[AST::Declarations::t]
-      def self.write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls) -> untyped
+      def self.write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls) -> void
 
       # @rbs *lines: String
       # @rbs return: void

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -152,14 +152,14 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
 
   def test_type_assertion
     annots = AnnotationParser.parse(parse_comments(<<~RUBY))
-      #:: (String) -> void
-      #:: [Integer, String]
-      #:: [Integer
-      #:: (
+      #: (String) -> void
+      #: [Integer, String]
+      #: [Integer
+      #: (
       #    String,
       #    Integer,
       #   ) -> void
-      # :: String
+      # : String
       RUBY
 
     annots[0].annotations[0].tap do |annotation|

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -15,7 +15,7 @@ class RBS::Inline::WriterTest < Minitest::Test
     output = translate(<<~RUBY)
       class Foo
         # @rbs () -> String
-        #:: (String) -> Integer
+        #: (String) -> Integer
         def foo(x = nil)
         end
 
@@ -34,7 +34,7 @@ class RBS::Inline::WriterTest < Minitest::Test
     assert_equal <<~RBS, output
       class Foo
         # @rbs () -> String
-        # :: (String) -> Integer
+        # : (String) -> Integer
         def foo: () -> String
                | (String) -> Integer
 
@@ -120,17 +120,17 @@ class RBS::Inline::WriterTest < Minitest::Test
   def test_method_type__return_assertion
     output = translate(<<~RUBY)
       class Foo
-        def to_s #:: String
+        def to_s #: String
         end
 
         def foo(
             x,
             y
-          ) #:: void
+          ) #: void
         end
 
         def hoge x,
-          y #:: Integer
+          y #: Integer
         end
       end
     RUBY
@@ -362,12 +362,12 @@ class RBS::Inline::WriterTest < Minitest::Test
   def test_attributes__typed
     output = translate(<<~RUBY)
       class Hello
-        attr_reader :foo, :foo2, "hoge".to_sym #:: String
+        attr_reader :foo, :foo2, "hoge".to_sym #: String
 
         # Attribute of bar
-        attr_writer :bar #:: Array[Integer]
+        attr_writer :bar #: Array[Integer]
 
-        attr_accessor :baz #:: Integer |
+        attr_accessor :baz #: Integer |
       end
     RUBY
 
@@ -465,7 +465,7 @@ class RBS::Inline::WriterTest < Minitest::Test
     output = translate(<<~RUBY)
       VERSION = "hogehoge"
 
-      SIZE = [123] #:: Array[Integer]
+      SIZE = [123] #: Array[Integer]
 
       NAMES = __dir__
 
@@ -511,7 +511,7 @@ class RBS::Inline::WriterTest < Minitest::Test
       module Foo
         # @rbs @foo: String -- This is something
 
-        def foo #:: void
+        def foo #: void
         end
 
         # @rbs self.@foo: Integer -- Something another


### PR DESCRIPTION
This PR also bundles steep-1.8.0.dev.1, which has changes for `#:` annotation (https://github.com/soutaro/steep/pull/1176, https://github.com/soutaro/steep/pull/1179).

Related to: https://github.com/soutaro/rbs-inline/issues/7