### PR TITLE
Add `...` syntax for overloading

### DIFF
--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -602,16 +602,22 @@ module RBS
           end
         when tokenizer.type?(:kCOLON)
           tokenizer.advance(tree, eat: true)
-          type = parse_type_method_type(tokenizer, tree)
-          tree << type
 
-          case type
-          when MethodType
-            AST::Annotations::MethodTypeAssertion.new(tree, comments)
-          when AST::Tree, nil
-            AST::Annotations::SyntaxErrorAssertion.new(tree, comments)
+          if tokenizer.type?(:kDOT3)
+            tokenizer.advance(tree, eat: true)
+            AST::Annotations::Dot3Assertion.new(tree, comments)
           else
-            AST::Annotations::TypeAssertion.new(tree, comments)
+            type = parse_type_method_type(tokenizer, tree)
+            tree << type
+
+            case type
+            when MethodType
+              AST::Annotations::MethodTypeAssertion.new(tree, comments)
+            when AST::Tree, nil
+              AST::Annotations::SyntaxErrorAssertion.new(tree, comments)
+            else
+              AST::Annotations::TypeAssertion.new(tree, comments)
+            end
           end
         when tokenizer.type?(:kLBRACKET)
           tree << parse_type_app(tokenizer)

--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -602,8 +602,17 @@ module RBS
           end
         when tokenizer.type?(:kCOLON)
           tokenizer.advance(tree, eat: true)
-          tree << parse_type_method_type(tokenizer, tree)
-          AST::Annotations::Assertion.new(tree, comments)
+          type = parse_type_method_type(tokenizer, tree)
+          tree << type
+
+          case type
+          when MethodType
+            AST::Annotations::MethodTypeAssertion.new(tree, comments)
+          when AST::Tree, nil
+            AST::Annotations::SyntaxErrorAssertion.new(tree, comments)
+          else
+            AST::Annotations::TypeAssertion.new(tree, comments)
+          end
         when tokenizer.type?(:kLBRACKET)
           tree << parse_type_app(tokenizer)
           AST::Annotations::Application.new(tree, comments)

--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -12,7 +12,7 @@ module RBS
         #          | Generic
         #          | ModuleSelf
         #          | Skip
-        #          | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion
+        #          | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion
         #          | Application
         #          | RBSAnnotation
         #          | Override
@@ -266,6 +266,14 @@ module RBS
             @source = source
 
             @error_string = tree.nth_tree(1).to_s
+          end
+        end
+
+        class Dot3Assertion < Base
+          # @rbs override
+          def initialize(tree, source)
+            @tree = tree
+            @source = source
           end
         end
 

--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -164,11 +164,11 @@ module RBS
 
           attr_reader :node #: Prism::ConstantWriteNode
           attr_reader :comments #: AnnotationParser::ParsingResult?
-          attr_reader :assertion #: Annotations::Assertion?
+          attr_reader :assertion #: Annotations::TypeAssertion?
 
           # @rbs node: Prism::ConstantWriteNode
           # @rbs comments: AnnotationParser::ParsingResult?
-          # @rbs assertion: Annotations::Assertion?
+          # @rbs assertion: Annotations::TypeAssertion?
           def initialize(node, comments, assertion) #: void
             @node = node
             @comments = comments

--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -41,6 +41,8 @@ module RBS
           # ```
           attr_reader :visibility #: RBS::AST::Members::visibility?
 
+          # Assertion given at the end of the method name
+          #
           attr_reader :assertion #: Annotations::TypeAssertion?
 
           # @rbs node: Prism::DefNode
@@ -68,7 +70,7 @@ module RBS
           def annotated_method_types #: Array[MethodType]?
             if comments
               method_type_annotations = comments.each_annotation.select do |annotation|
-                annotation.is_a?(Annotations::MethodTypeAssertion) || annotation.is_a?(Annotations::Method)
+                annotation.is_a?(Annotations::MethodTypeAssertion) || annotation.is_a?(Annotations::Method) || annotation.is_a?(Annotations::Dot3Assertion)
               end
 
               return nil if method_type_annotations.empty?
@@ -139,6 +141,9 @@ module RBS
               comments.each_annotation do |annotation|
                 if annotation.is_a?(Annotations::Method)
                   return true if annotation.overloading
+                end
+                if annotation.is_a?(Annotations::Dot3Assertion)
+                  return true
                 end
               end
               false

--- a/lib/rbs/inline/ast/tree.rb
+++ b/lib/rbs/inline/ast/tree.rb
@@ -3,12 +3,12 @@
 module RBS
   module Inline
     module AST
-      class Tree
-        # @rbs!
-        #   type token = [Symbol, String]
-        #
-        #   type tree = token | Tree | Types::t | MethodType | nil
+      # @rbs!
+      #   type token = [Symbol, String]
+      #
+      #   type tree = token | Tree | Types::t | MethodType | nil
 
+      class Tree
         attr_reader :trees #: Array[tree]
         attr_reader :type #: Symbol
 
@@ -50,6 +50,20 @@ module RBS
           end
 
           buf
+        end
+
+        # Returns `true` if token at the given index is of the given type
+        def token?(type, at:)
+          if tok = nth_token?(at)
+            tok[0] == type
+          end
+        end
+
+         # Returns `true` if tree at the given index is of the given type
+         def tree?(type, at:)
+          if tree = nth_tree?(at)
+            tree.type == type
+          end
         end
 
         # Returns n-th token from the children

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -257,8 +257,8 @@ module RBS
             if assertion_comment && comment_line
               comments.delete(comment_line)
               assertion = assertion_comment.each_annotation.find do |annotation|
-                annotation.is_a?(AST::Annotations::Assertion)
-              end #: AST::Annotations::Assertion?
+                annotation.is_a?(AST::Annotations::TypeAssertion)
+              end #: AST::Annotations::TypeAssertion?
             end
 
             current_class_module_decl!.members << AST::Members::RubyAttr.new(node, comment, assertion)
@@ -338,12 +338,12 @@ module RBS
         end
       end
 
-      # Fetch Assertion annotation which is associated to `node`
+      # Fetch TypeAssertion annotation which is associated to `node`
       #
       # The assertion annotation is removed from `comments`.
       #
       # @rbs node: Node | Location
-      # @rbs return: AST::Annotations::Assertion?
+      # @rbs return: AST::Annotations::TypeAssertion?
       def assertion_annotation(node)
         if node.is_a?(Prism::Location)
           location = node
@@ -357,8 +357,8 @@ module RBS
         if app_comment && comment_line
           comments.delete(comment_line)
           app_comment.each_annotation.find do |annotation|
-            annotation.is_a?(AST::Annotations::Assertion)
-          end #: AST::Annotations::Assertion?
+            annotation.is_a?(AST::Annotations::TypeAssertion)
+          end #: AST::Annotations::TypeAssertion?
         end
       end
 

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -206,7 +206,7 @@ module RBS
               annotations: member.method_annotations,
               location: nil,
               comment: comment,
-              overloading: false,
+              overloading: member.overloading?,
               visibility: member.visibility
             )
           ]

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -198,12 +198,32 @@ module RBS
 
         # `@rbs METHOD-TYPE``
         class Method < Base
+          type method_type = [ MethodType, method_type? ] | String
+
+          attr_reader method_types: method_type?
+
+          # `true` if the method definition is overloading something
+          attr_reader overloading: bool
+
           attr_reader type: MethodType?
 
           attr_reader method_type_source: String
 
           # @rbs override
           def initialize: ...
+
+          # : (Array[tree]) -> method_type?
+          def construct_method_types: (Array[tree]) -> method_type?
+
+          # @rbs () { (MethodType) -> void } -> void
+          #    | () -> Enumerator[MethodType, void]
+          def each_method_type: () { (MethodType) -> void } -> void
+                              | () -> Enumerator[MethodType, void]
+
+          # Returns the parsing error overload string
+          #
+          # Returns `nil` if no parsing error found.
+          def error_source: () -> String?
         end
       end
     end

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,7 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType
 
         class Base
           attr_reader source: CommentLines
@@ -114,6 +114,11 @@ module RBS
         class SyntaxErrorAssertion < Base
           attr_reader error_string: String
 
+          # @rbs override
+          def initialize: ...
+        end
+
+        class Dot3Assertion < Base
           # @rbs override
           def initialize: ...
         end

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,7 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType
 
         class Base
           attr_reader source: CommentLines
@@ -93,21 +93,29 @@ module RBS
           def initialize: ...
         end
 
-        # `#: TYPE`
-        class Assertion < Base
-          attr_reader type: Types::t | MethodType | nil
+        class MethodTypeAssertion < Base
+          attr_reader method_type: MethodType
 
           # @rbs override
           def initialize: ...
 
-          # @rbs return: bool
-          def complete?: () -> bool
+          def type_source: () -> String
+        end
 
-          # Returns a type if it's type
-          def type?: () -> Types::t?
+        class TypeAssertion < Base
+          attr_reader type: Types::t
 
-          # Returns a method type if it's a method type
-          def method_type?: () -> MethodType?
+          # @rbs override
+          def initialize: ...
+
+          def type_source: () -> String
+        end
+
+        class SyntaxErrorAssertion < Base
+          attr_reader error_string: String
+
+          # @rbs override
+          def initialize: ...
         end
 
         # `#[TYPE, ..., TYPE]`

--- a/sig/generated/rbs/inline/ast/declarations.rbs
+++ b/sig/generated/rbs/inline/ast/declarations.rbs
@@ -86,12 +86,12 @@ module RBS
 
           attr_reader comments: AnnotationParser::ParsingResult?
 
-          attr_reader assertion: Annotations::Assertion?
+          attr_reader assertion: Annotations::TypeAssertion?
 
           # @rbs node: Prism::ConstantWriteNode
           # @rbs comments: AnnotationParser::ParsingResult?
-          # @rbs assertion: Annotations::Assertion?
-          def initialize: (Prism::ConstantWriteNode node, AnnotationParser::ParsingResult? comments, Annotations::Assertion? assertion) -> void
+          # @rbs assertion: Annotations::TypeAssertion?
+          def initialize: (Prism::ConstantWriteNode node, AnnotationParser::ParsingResult? comments, Annotations::TypeAssertion? assertion) -> void
 
           # @rbs %a{pure}
           # @rbs return: Types::t

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -37,13 +37,13 @@ module RBS
           # ```
           attr_reader visibility: RBS::AST::Members::visibility?
 
-          attr_reader assertion: Annotations::Assertion?
+          attr_reader assertion: Annotations::TypeAssertion?
 
           # @rbs node: Prism::DefNode
           # @rbs comments: AnnotationParser::ParsingResult?
           # @rbs visibility: RBS::AST::Members::visibility?
-          # @rbs assertion: Annotations::Assertion?
-          def initialize: (Prism::DefNode node, AnnotationParser::ParsingResult? comments, RBS::AST::Members::visibility? visibility, Annotations::Assertion? assertion) -> void
+          # @rbs assertion: Annotations::TypeAssertion?
+          def initialize: (Prism::DefNode node, AnnotationParser::ParsingResult? comments, RBS::AST::Members::visibility? visibility, Annotations::TypeAssertion? assertion) -> void
 
           # Returns the name of the method
           def method_name: () -> Symbol
@@ -119,13 +119,13 @@ module RBS
 
           attr_reader comments: AnnotationParser::ParsingResult?
 
-          attr_reader assertion: Annotations::Assertion?
+          attr_reader assertion: Annotations::TypeAssertion?
 
           # @rbs node: Prism::CallNode
           # @rbs comments: AnnotationParser::ParsingResult?
-          # @rbs assertion: Annotations::Assertion?
+          # @rbs assertion: Annotations::TypeAssertion?
           # @rbs return: void
-          def initialize: (Prism::CallNode node, AnnotationParser::ParsingResult? comments, Annotations::Assertion? assertion) -> void
+          def initialize: (Prism::CallNode node, AnnotationParser::ParsingResult? comments, Annotations::TypeAssertion? assertion) -> void
 
           # @rbs return Array[RBS::AST::Members::AttrReader | RBS::AST::Members::AttrWriter | RBS::AST::Members::AttrAccessor]?
           def rbs: () -> Array[RBS::AST::Members::AttrReader | RBS::AST::Members::AttrWriter | RBS::AST::Members::AttrAccessor]?

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -48,7 +48,10 @@ module RBS
           # Returns the name of the method
           def method_name: () -> Symbol
 
-          def annotated_method_types: () -> Array[MethodType]
+          # Returns `nil` if no `@rbs METHOD-TYPE` or `#:` annotation is given
+          #
+          # Returns an empty array if only `...` method type is given.
+          def annotated_method_types: () -> Array[MethodType]?
 
           def return_type: () -> Types::t?
 
@@ -58,10 +61,13 @@ module RBS
 
           def double_splat_param_type_annotation: () -> Annotations::DoubleSplatParamType?
 
+          def overloading?: () -> bool
+
           def method_overloads: () -> Array[RBS::AST::Members::MethodDefinition::Overload]
 
           def method_annotations: () -> Array[RBS::AST::Annotation]
 
+          # Returns the `@rbs override` annotation
           def override_annotation: () -> AST::Annotations::Override?
 
           def block_type_annotation: () -> AST::Annotations::BlockType?

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -37,6 +37,7 @@ module RBS
           # ```
           attr_reader visibility: RBS::AST::Members::visibility?
 
+          # Assertion given at the end of the method name
           attr_reader assertion: Annotations::TypeAssertion?
 
           # @rbs node: Prism::DefNode

--- a/sig/generated/rbs/inline/ast/tree.rbs
+++ b/sig/generated/rbs/inline/ast/tree.rbs
@@ -3,11 +3,11 @@
 module RBS
   module Inline
     module AST
+      type token = [ Symbol, String ]
+
+      type tree = token | Tree | Types::t | MethodType | nil
+
       class Tree
-        type token = [ Symbol, String ]
-
-        type tree = token | Tree | Types::t | MethodType | nil
-
         attr_reader trees: Array[tree]
 
         attr_reader type: Symbol
@@ -24,6 +24,12 @@ module RBS
 
         # Returns the source code associated to the tree
         def to_s: () -> String
+
+        # Returns `true` if token at the given index is of the given type
+        def token?: (untyped type, at: untyped) -> untyped
+
+        # Returns `true` if tree at the given index is of the given type
+        def tree?: (untyped type, at: untyped) -> untyped
 
         # Returns n-th token from the children
         #

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -105,13 +105,13 @@ module RBS
       # @rbs return: AST::Annotations::Application?
       def application_annotation: (Node node) -> AST::Annotations::Application?
 
-      # Fetch Assertion annotation which is associated to `node`
+      # Fetch TypeAssertion annotation which is associated to `node`
       #
       # The assertion annotation is removed from `comments`.
       #
       # @rbs node: Node | Location
-      # @rbs return: AST::Annotations::Assertion?
-      def assertion_annotation: (Node | Location node) -> AST::Annotations::Assertion?
+      # @rbs return: AST::Annotations::TypeAssertion?
+      def assertion_annotation: (Node | Location node) -> AST::Annotations::TypeAssertion?
 
       # @rbs override
       def visit_constant_write_node: ...

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -152,30 +152,37 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
 
   def test_type_assertion
     annots = AnnotationParser.parse(parse_comments(<<~RUBY))
-      #: (String) -> void
       #: [Integer, String]
       #: [Integer
-      #: (
-      #    String,
-      #    Integer,
-      #   ) -> void
       # : String
       RUBY
 
     annots[0].annotations[0].tap do |annotation|
-      assert_equal "(String) -> void", annotation.type.to_s
-    end
-    annots[0].annotations[1].tap do |annotation|
+      assert_instance_of AST::Annotations::TypeAssertion, annotation
       assert_equal "[ Integer, String ]", annotation.type.to_s
     end
-    annots[0].annotations[2].tap do |annotation|
-      assert_nil annotation.type
+    annots[0].annotations[1].tap do |annotation|
+      assert_instance_of AST::Annotations::SyntaxErrorAssertion, annotation
+      assert_equal "[Integer\n : String", annotation.error_string
     end
-    annots[0].annotations[3].tap do |annotation|
-      assert_equal "(String, Integer) -> void", annotation.type.to_s
+  end
+
+  def test_method_type_assertion
+    annots = AnnotationParser.parse(parse_comments(<<~RUBY))
+      #: (String) -> void
+      #: (
+      #    String,
+      #    Integer,
+      #   ) -> void
+      RUBY
+
+    annots[0].annotations[0].tap do |annotation|
+      assert_instance_of AST::Annotations::MethodTypeAssertion, annotation
+      assert_equal "(String) -> void", annotation.method_type.to_s
     end
-    annots[0].annotations[4].tap do |annotation|
-      assert_nil annotation
+    annots[0].annotations[1].tap do |annotation|
+      assert_instance_of AST::Annotations::MethodTypeAssertion, annotation
+      assert_equal "(String, Integer) -> void", annotation.method_type.to_s
     end
   end
 

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -186,6 +186,16 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
     end
   end
 
+  def test_dot3_assertion
+    annots = AnnotationParser.parse(parse_comments(<<~RUBY))
+      #: ...
+      RUBY
+
+    annots[0].annotations[0].tap do |annotation|
+      assert_instance_of AST::Annotations::Dot3Assertion, annotation
+    end
+  end
+
   def test_type_application
     annots = AnnotationParser.parse(parse_comments(<<~RUBY))
       #[String, Integer]

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -655,4 +655,29 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_method_type_rbs_dot3
+    output = translate(<<~RUBY)
+      class X
+        # @rbs ...
+        def foo
+        end
+
+        # @rbs () -> void | ...
+        def bar
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class X
+        # @rbs ...
+        def foo: ...
+
+        # @rbs () -> void | ...
+        def bar: () -> void
+               | ...
+      end
+    RBS
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -680,4 +680,31 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_method_type_assertion_dot3
+    output = translate(<<~RUBY)
+      class X
+        #: ...
+        def foo
+        end
+
+        #: () -> void
+        #: ...
+        def bar
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class X
+        # : ...
+        def foo: ...
+
+        # : () -> void
+        # : ...
+        def bar: () -> void
+               | ...
+      end
+    RBS
+  end
 end


### PR DESCRIPTION
```rbs
# @rbs () -> void
# @rbs ...
def foo = nil

# => def foo: () -> void | ...

# Having several overloads is supported with `@rbs` syntax.

# @rbs () -> void
#    | ...
def bar = nil

# => def bar: () -> void | ...

# `#:` syntax also allows `...`
#: () -> void
#: ...
def baz = nil

# => def baz: () -> void | ...
```

Note that we don't support writing `|` overloads with `#:` syntax. This is because `#|` is not shorter than `#:`.

See https://github.com/soutaro/rbs-inline/issues/9