### PR TITLE
Implement class/module declaration via blocks

### DIFF
--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -320,10 +320,13 @@ module RBS
           when tokenizer.type?(T_LVAR, :tELVAR)
             tree << parse_var_decl(tokenizer)
             AST::Annotations::VarType.new(tree, comments)
-          when tokenizer.type?(K_SKIP, K_INHERITS, K_OVERRIDE, K_USE, K_GENERIC) &&
+          when tokenizer.type?(K_SKIP, K_INHERITS, K_OVERRIDE, K_USE, K_GENERIC, K_MODULE) &&
             tokenizer.type2?(K_COLON)
             tree << parse_var_decl(tokenizer)
             AST::Annotations::VarType.new(tree, comments)
+          when tokenizer.type?(K_MODULE)
+            tree << parse_module_decl(tokenizer)
+            AST::Annotations::ModuleDecl.new(tree, comments)
           when tokenizer.type?(K_SKIP)
             AST::Annotations::Skip.new(tree, comments)
           when tokenizer.type?(K_RETURN)
@@ -790,6 +793,19 @@ module RBS
 
         tokenizer.consume_token!(K_GENERIC, tree: tree)
 
+        tree << parse_type_param(tokenizer)
+
+        tree << parse_optional(tokenizer, K_MINUS2, tree: tree) do
+          parse_comment(tokenizer)
+        end
+
+        tree
+      end
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_type_param(tokenizer)
+        tree = AST::Tree.new(:type_param)
+
         tokenizer.consume_token(K_UNCHECKED, tree: tree)
         tokenizer.consume_token(K_IN, K_OUT, tree: tree)
 
@@ -802,10 +818,6 @@ module RBS
           bound << parse_type(tokenizer, bound)
 
           bound
-        end
-
-        tree << parse_optional(tokenizer, K_MINUS2, tree: tree) do
-          parse_comment(tokenizer)
         end
 
         tree
@@ -867,6 +879,80 @@ module RBS
 
         tree << parse_optional(tokenizer, K_MINUS2, tree: tree) do
           parse_comment(tokenizer)
+        end
+
+        tree
+      end
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_module_decl(tokenizer)
+        tree = AST::Tree.new(:module_decl)
+
+        tokenizer.consume_token!(K_MODULE, tree: tree)
+
+        tree << parse_module_name(tokenizer)
+
+        tree << parse_optional(tokenizer, K_LBRACKET) do
+          parse_type_params(tokenizer)
+        end
+
+        tree << parse_optional(tokenizer, K_COLON) do
+          parse_module_selfs(tokenizer)
+        end
+
+        tree
+      end
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_module_name(tokenizer)
+        tree = AST::Tree.new(:module_name)
+
+        tokenizer.consume_token(K_COLON2, tree: tree)
+
+        while tokenizer.type?(T_UIDENT) && tokenizer.type2?(K_COLON2)
+          tokenizer.consume_token!(T_UIDENT, tree: tree)
+          tokenizer.consume_token!(K_COLON2, tree: tree)
+        end
+
+        tokenizer.consume_token(T_UIDENT, tree: tree)
+
+        tree
+      end
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_type_params(tokenizer)
+        tree = AST::Tree.new(:type_params)
+
+        tokenizer.consume_token!(K_LBRACKET, tree: tree)
+
+        while true
+          if type_param = parse_optional(tokenizer, T_UIDENT, K_UNCHECKED, K_IN, K_OUT) { parse_type_param(tokenizer) }
+            tree << type_param
+            break if tokenizer.type?(K_RBRACKET)
+            tokenizer.consume_token(K_COMMA, tree: tree)
+          else
+            break
+          end
+        end
+
+        tokenizer.consume_token(K_RBRACKET, tree: tree)
+
+        tree
+      end
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_module_selfs(tokenizer)
+        tree = AST::Tree.new(:module_selfs)
+
+        tokenizer.consume_token!(K_COLON, tree: tree)
+
+        while true
+          tree << parse_type(tokenizer, tree)
+          if tokenizer.type?(K_COMMA)
+            tokenizer.advance(tree, eat: true)
+          else
+            break
+          end
         end
 
         tree

--- a/lib/rbs/inline/annotation_parser/tokenizer.rb
+++ b/lib/rbs/inline/annotation_parser/tokenizer.rb
@@ -80,6 +80,7 @@ module RBS
           "self" => K_SELF,
           "skip" => K_SKIP,
           "yields" => K_YIELDS,
+          "module" => K_MODULE,
         } #: Hash[String, Symbol]
         KW_RE = /#{Regexp.union(KEYWORDS.keys)}\b/
 

--- a/lib/rbs/inline/annotation_parser/tokenizer.rb
+++ b/lib/rbs/inline/annotation_parser/tokenizer.rb
@@ -16,6 +16,7 @@ module RBS
         K_SKIP = :kSKIP
         K_YIELDS = :kYIELDS
         K_MODULE = :kMODULE
+        K_CLASS = :kCLASS
         K_COLON2 = :kCOLON2
         K_COLON = :kCOLON
         K_LBRACKET = :kLBRACKET
@@ -81,6 +82,7 @@ module RBS
           "skip" => K_SKIP,
           "yields" => K_YIELDS,
           "module" => K_MODULE,
+          "class" => K_CLASS,
         } #: Hash[String, Symbol]
         KW_RE = /#{Regexp.union(KEYWORDS.keys)}\b/
 

--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -16,7 +16,7 @@ module RBS
         end
 
         # @rbs!
-        #   type t = ClassDecl | ModuleDecl | ConstantDecl | SingletonClassDecl
+        #   type t = ClassDecl | ModuleDecl | ConstantDecl | SingletonClassDecl | BlockDecl
         #
         #  interface _WithComments
         #    def comments: () -> AnnotationParser::ParsingResult?
@@ -229,6 +229,34 @@ module RBS
         end
 
         class SingletonClassDecl < ModuleOrClass #[Prism::SingletonClassNode]
+        end
+
+        class BlockDecl < Base
+          attr_reader :node #: Prism::BlockNode
+
+          attr_reader :comments #: AnnotationParser::ParsingResult?
+
+          # Members included in the declaration
+          attr_reader :members #: Array[Members::t | t]
+
+          # @rbs (Prism::BlockNode, AnnotationParser::ParsingResult?) -> void
+          def initialize(node, comments)
+            @node = node
+            @members = []
+            @comments = comments
+          end
+
+          def start_line #: Integer
+            node.location.start_line
+          end
+
+          def module_class_annotation #: Annotations::ModuleDecl?
+            if comments
+              comments.each_annotation.find do |annotation|
+                annotation.is_a?(Annotations::ModuleDecl)
+              end #: Annotations::ModuleDecl
+            end
+          end
         end
       end
     end

--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -250,11 +250,19 @@ module RBS
             node.location.start_line
           end
 
-          def module_class_annotation #: Annotations::ModuleDecl?
+          def module_class_annotation #: Annotations::ModuleDecl | Annotations::ClassDecl | nil
             if comments
-              comments.each_annotation.find do |annotation|
-                annotation.is_a?(Annotations::ModuleDecl)
-              end #: Annotations::ModuleDecl
+              comments.each_annotation.each do |annotation|
+                if annotation.is_a?(Annotations::ModuleDecl)
+                  return annotation
+                end
+
+                if annotation.is_a?(Annotations::ClassDecl)
+                  return annotation
+                end
+              end
+
+              nil
             end
           end
         end

--- a/lib/rbs/inline/ast/tree.rb
+++ b/lib/rbs/inline/ast/tree.rb
@@ -59,8 +59,8 @@ module RBS
           end
         end
 
-         # Returns `true` if tree at the given index is of the given type
-         def tree?(type, at:)
+        # Returns `true` if tree at the given index is of the given type
+        def tree?(type, at:)
           if tree = nth_tree?(at)
             tree.type == type
           end

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -8,6 +8,7 @@ module RBS
       # @rbs! type with_members = AST::Declarations::ModuleDecl
       #                         | AST::Declarations::ClassDecl
       #                         | AST::Declarations::SingletonClassDecl
+      #                         | AST::Declarations::BlockDecl
 
       # The top level declarations
       #
@@ -378,6 +379,18 @@ module RBS
           current.members << decl
         else
           decls << decl
+        end
+      end
+
+      # @rbs override
+      def visit_block_node(node)
+        return if ignored_node?(node)
+
+        comment = comments.delete(node.location.start_line - 1)
+        block = AST::Declarations::BlockDecl.new(node, comment)
+
+        push_class_module_decl(block) do
+          super
         end
       end
     end

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -5,13 +5,17 @@
 module RBS
   module Inline
     class Parser < Prism::Visitor
+      # @rbs! type with_members = AST::Declarations::ModuleDecl
+      #                         | AST::Declarations::ClassDecl
+      #                         | AST::Declarations::SingletonClassDecl
+
       # The top level declarations
       #
       attr_reader :decls #: Array[AST::Declarations::t]
 
       # The surrounding declarations
       #
-      attr_reader :surrounding_decls #: Array[AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl]
+      attr_reader :surrounding_decls #: Array[with_members]
 
       # ParsingResult associated with the line number at the end
       #
@@ -76,18 +80,17 @@ module RBS
         ]
       end
 
-      # @rbs return: AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | nil
+      # @rbs return: with_members?
       def current_class_module_decl
         surrounding_decls.last
       end
 
-      # @rbs return: AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl
+      # @rbs return: with_members
       def current_class_module_decl!
         current_class_module_decl or raise
       end
 
-      #: (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
-      #: (AST::Declarations::ConstantDecl) -> void
+      #: (with_members) { () -> void } -> void
       def push_class_module_decl(decl)
         if current = current_class_module_decl
           current.members << decl
@@ -96,7 +99,7 @@ module RBS
         end
 
         if block_given?
-          surrounding_decls.push(_ = decl)
+          surrounding_decls.push(decl)
           begin
             yield
           ensure
@@ -370,7 +373,12 @@ module RBS
         assertion = assertion_annotation(node)
 
         decl = AST::Declarations::ConstantDecl.new(node, comment, assertion)
-        push_class_module_decl(decl)
+
+        if current = current_class_module_decl
+          current.members << decl
+        else
+          decls << decl
+        end
       end
     end
   end

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -89,7 +89,7 @@ module RBS
 
         decl.members.each do |member|
           if member.is_a?(AST::Members::Base)
-            translate_member(member, decl, members)
+            translate_member(member, nil, members)
           end
 
           if member.is_a?(AST::Declarations::SingletonClassDecl)
@@ -124,7 +124,7 @@ module RBS
 
         decl.members.each do |member|
           if member.is_a?(AST::Members::Base)
-            translate_member(member, decl, members)
+            translate_member(member, nil, members)
           end
 
           if member.is_a?(AST::Declarations::SingletonClassDecl)
@@ -177,7 +177,8 @@ module RBS
       end
 
       # @rbs member: AST::Members::t
-      # @rbs decl: AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl
+      # @rbs decl: AST::Declarations::SingletonClassDecl? --
+      #   The surrouding singleton class definition
       # @rbs rbs: _Content
       # @rbs return void
       def translate_member(member, decl, rbs)
@@ -266,10 +267,10 @@ module RBS
       # ```
       #
       # @rbs member: AST::Members::RubyDef
-      # @rbs decl: AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl
+      # @rbs decl: AST::Declarations::SingletonClassDecl?
       # @rbs return: RBS::AST::Members::MethodDefinition::kind
       def method_kind(member, decl)
-        return :singleton if decl.is_a?(AST::Declarations::SingletonClassDecl)
+        return :singleton if decl
 
         case member.node.receiver
         when Prism::SelfNode

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -247,6 +247,9 @@ module RBS
       # @rbs return: AST::Tree
       def parse_generic: (Tokenizer tokenizer) -> AST::Tree
 
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_type_param: (Tokenizer) -> AST::Tree
+
       # : (Tokenizer) -> AST::Tree
       def parse_ivar_type: (Tokenizer) -> AST::Tree
 
@@ -255,6 +258,18 @@ module RBS
 
       # : (Tokenizer) -> AST::Tree
       def parse_block_type: (Tokenizer) -> AST::Tree
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_module_decl: (Tokenizer) -> AST::Tree
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_module_name: (Tokenizer) -> AST::Tree
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_type_params: (Tokenizer) -> AST::Tree
+
+      # @rbs (Tokenizer) -> AST::Tree
+      def parse_module_selfs: (Tokenizer) -> AST::Tree
     end
   end
 end

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -263,6 +263,9 @@ module RBS
       def parse_module_decl: (Tokenizer) -> AST::Tree
 
       # @rbs (Tokenizer) -> AST::Tree
+      def parse_class_decl: (Tokenizer) -> AST::Tree
+
+      # @rbs (Tokenizer) -> AST::Tree
       def parse_module_name: (Tokenizer) -> AST::Tree
 
       # @rbs (Tokenizer) -> AST::Tree

--- a/sig/generated/rbs/inline/annotation_parser/tokenizer.rbs
+++ b/sig/generated/rbs/inline/annotation_parser/tokenizer.rbs
@@ -32,6 +32,8 @@ module RBS
 
         K_MODULE: ::Symbol
 
+        K_CLASS: ::Symbol
+
         K_COLON2: ::Symbol
 
         K_COLON: ::Symbol

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,21 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType | ModuleDecl
+
+        module Utils
+          # @rbs (Tree) -> RBS::AST::TypeParam?
+          def translate_type_param: (Tree) -> RBS::AST::TypeParam?
+
+          # Assumes the tree is generated through `#parse_module_name`
+          #
+          # Returns a type name, or `nil` if the tree is something invalid.
+          #
+          # @param tree -- A tree object that is generated through `#parse_module_name`
+          #
+          # @rbs (AST::Tree) -> TypeName?
+          def translate_type_name: (AST::Tree) -> TypeName?
+        end
 
         class Base
           attr_reader source: CommentLines
@@ -197,6 +211,8 @@ module RBS
 
           attr_reader comment: String?
 
+          include Utils
+
           # @rbs override
           def initialize: ...
         end
@@ -237,6 +253,20 @@ module RBS
           #
           # Returns `nil` if no parsing error found.
           def error_source: () -> String?
+        end
+
+        # `@rbs module Foo`
+        class ModuleDecl < Base
+          attr_reader name: TypeName?
+
+          attr_reader type_params: Array[RBS::AST::TypeParam]
+
+          attr_reader self_types: Array[RBS::AST::Declarations::Module::Self]
+
+          include Utils
+
+          # @rbs override
+          def initialize: ...
         end
       end
     end

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,11 +4,14 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType | ModuleDecl
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType | ModuleDecl | ClassDecl
 
         module Utils
           # @rbs (Tree) -> RBS::AST::TypeParam?
           def translate_type_param: (Tree) -> RBS::AST::TypeParam?
+
+          # @rbs (Types::t) -> RBS::AST::Declarations::Class::Super?
+          def translate_super_class: (Types::t) -> RBS::AST::Declarations::Class::Super?
 
           # Assumes the tree is generated through `#parse_module_name`
           #
@@ -262,6 +265,20 @@ module RBS
           attr_reader type_params: Array[RBS::AST::TypeParam]
 
           attr_reader self_types: Array[RBS::AST::Declarations::Module::Self]
+
+          include Utils
+
+          # @rbs override
+          def initialize: ...
+        end
+
+        # `@rbs class Foo`
+        class ClassDecl < Base
+          attr_reader name: TypeName?
+
+          attr_reader type_params: Array[RBS::AST::TypeParam]
+
+          attr_reader super_class: RBS::AST::Declarations::Class::Super?
 
           include Utils
 

--- a/sig/generated/rbs/inline/ast/declarations.rbs
+++ b/sig/generated/rbs/inline/ast/declarations.rbs
@@ -127,7 +127,7 @@ module RBS
 
           def start_line: () -> Integer
 
-          def module_class_annotation: () -> Annotations::ModuleDecl?
+          def module_class_annotation: () -> (Annotations::ModuleDecl | Annotations::ClassDecl | nil)
         end
       end
     end

--- a/sig/generated/rbs/inline/ast/declarations.rbs
+++ b/sig/generated/rbs/inline/ast/declarations.rbs
@@ -10,7 +10,7 @@ module RBS
           def type_name: (Prism::Node node) -> TypeName?
         end
 
-        type t = ClassDecl | ModuleDecl | ConstantDecl | SingletonClassDecl
+        type t = ClassDecl | ModuleDecl | ConstantDecl | SingletonClassDecl | BlockDecl
 
         interface _WithComments
           def comments: () -> AnnotationParser::ParsingResult?
@@ -112,6 +112,22 @@ module RBS
         end
 
         class SingletonClassDecl < ModuleOrClass[Prism::SingletonClassNode]
+        end
+
+        class BlockDecl < Base
+          attr_reader node: Prism::BlockNode
+
+          attr_reader comments: AnnotationParser::ParsingResult?
+
+          # Members included in the declaration
+          attr_reader members: Array[Members::t | t]
+
+          # @rbs (Prism::BlockNode, AnnotationParser::ParsingResult?) -> void
+          def initialize: (Prism::BlockNode, AnnotationParser::ParsingResult?) -> void
+
+          def start_line: () -> Integer
+
+          def module_class_annotation: () -> Annotations::ModuleDecl?
         end
       end
     end

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -5,11 +5,13 @@ use Prism::*
 module RBS
   module Inline
     class Parser < Prism::Visitor
+      type with_members = AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl
+
       # The top level declarations
       attr_reader decls: Array[AST::Declarations::t]
 
       # The surrounding declarations
-      attr_reader surrounding_decls: Array[AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl]
+      attr_reader surrounding_decls: Array[with_members]
 
       # ParsingResult associated with the line number at the end
       #
@@ -35,16 +37,14 @@ module RBS
       # @rbs return: [Array[AST::Annotations::Use], Array[AST::Declarations::t]]?
       def self.parse: (ParseResult result, opt_in: bool) -> [ Array[AST::Annotations::Use], Array[AST::Declarations::t] ]?
 
-      # @rbs return: AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | nil
-      def current_class_module_decl: () -> (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | nil)
+      # @rbs return: with_members?
+      def current_class_module_decl: () -> with_members?
 
-      # @rbs return: AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl
-      def current_class_module_decl!: () -> (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl)
+      # @rbs return: with_members
+      def current_class_module_decl!: () -> with_members
 
-      # : (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
-      # : (AST::Declarations::ConstantDecl) -> void
-      def push_class_module_decl: (AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl) { () -> void } -> void
-                                | (AST::Declarations::ConstantDecl) -> void
+      # : (with_members) { () -> void } -> void
+      def push_class_module_decl: (with_members) { () -> void } -> void
 
       # Load inner declarations and delete them from `#comments` hash
       #

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -5,7 +5,7 @@ use Prism::*
 module RBS
   module Inline
     class Parser < Prism::Visitor
-      type with_members = AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl
+      type with_members = AST::Declarations::ModuleDecl | AST::Declarations::ClassDecl | AST::Declarations::SingletonClassDecl | AST::Declarations::BlockDecl
 
       # The top level declarations
       attr_reader decls: Array[AST::Declarations::t]
@@ -115,6 +115,9 @@ module RBS
 
       # @rbs override
       def visit_constant_write_node: ...
+
+      # @rbs override
+      def visit_block_node: ...
     end
   end
 end

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -55,10 +55,11 @@ module RBS
       def translate_singleton_decl: (AST::Declarations::SingletonClassDecl decl, _Content rbs) -> void
 
       # @rbs member: AST::Members::t
-      # @rbs decl: AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl
+      # @rbs decl: AST::Declarations::SingletonClassDecl? --
+      #   The surrouding singleton class definition
       # @rbs rbs: _Content
       # @rbs return void
-      def translate_member: (AST::Members::t member, AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl decl, _Content rbs) -> void
+      def translate_member: (AST::Members::t member, AST::Declarations::SingletonClassDecl? decl, _Content rbs) -> void
 
       private
 
@@ -76,9 +77,9 @@ module RBS
       # ```
       #
       # @rbs member: AST::Members::RubyDef
-      # @rbs decl: AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl
+      # @rbs decl: AST::Declarations::SingletonClassDecl?
       # @rbs return: RBS::AST::Members::MethodDefinition::kind
-      def method_kind: (AST::Members::RubyDef member, AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl decl) -> RBS::AST::Members::MethodDefinition::kind
+      def method_kind: (AST::Members::RubyDef member, AST::Declarations::SingletonClassDecl? decl) -> RBS::AST::Members::MethodDefinition::kind
     end
   end
 end

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -3,6 +3,12 @@
 module RBS
   module Inline
     class Writer
+      interface _Content
+        def <<: (RBS::AST::Declarations::t | RBS::AST::Members::t) -> void
+
+        def concat: (Array[RBS::AST::Declarations::t | RBS::AST::Members::t]) -> void
+      end
+
       attr_reader output: String
 
       attr_reader writer: RBS::Writer
@@ -24,29 +30,35 @@ module RBS
       def write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls) -> void
 
       # @rbs decl: AST::Declarations::t
-      # @rbs return: RBS::AST::Declarations::t?
-      def translate_decl: (AST::Declarations::t decl) -> RBS::AST::Declarations::t?
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_decl: (AST::Declarations::t decl, _Content rbs) -> void
 
       # @rbs decl: AST::Declarations::ClassDecl
-      # @rbs return: RBS::AST::Declarations::Class?
-      def translate_class_decl: (AST::Declarations::ClassDecl decl) -> RBS::AST::Declarations::Class?
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_class_decl: (AST::Declarations::ClassDecl decl, _Content rbs) -> void
 
       # @rbs decl: AST::Declarations::ModuleDecl
-      # @rbs return: RBS::AST::Declarations::Module?
-      def translate_module_decl: (AST::Declarations::ModuleDecl decl) -> RBS::AST::Declarations::Module?
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_module_decl: (AST::Declarations::ModuleDecl decl, _Content rbs) -> void
 
       # @rbs decl: AST::Declarations::ConstantDecl
-      # @rbs return: RBS::AST::Declarations::Constant?
-      def translate_constant_decl: (AST::Declarations::ConstantDecl decl) -> RBS::AST::Declarations::Constant?
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_constant_decl: (AST::Declarations::ConstantDecl decl, _Content rbs) -> void
 
       # @rbs decl: AST::Declarations::SingletonClassDecl
-      # @rbs return: Array[RBS::AST::Members::t]
-      def translate_singleton_decl: (AST::Declarations::SingletonClassDecl decl) -> Array[RBS::AST::Members::t]
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_singleton_decl: (AST::Declarations::SingletonClassDecl decl, _Content rbs) -> void
 
       # @rbs member: AST::Members::t
       # @rbs decl: AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl
-      # @rbs return: Array[RBS::AST::Members::t | RBS::AST::Declarations::t]?
-      def translate_member: (AST::Members::t member, AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl decl) -> Array[RBS::AST::Members::t | RBS::AST::Declarations::t]?
+      # @rbs rbs: _Content
+      # @rbs return void
+      def translate_member: (AST::Members::t member, AST::Declarations::ClassDecl | AST::Declarations::ModuleDecl | AST::Declarations::SingletonClassDecl decl, _Content rbs) -> void
 
       private
 

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -91,6 +91,11 @@ module RBS
       # @rbs rbs: _Content
       # @rbs return: void
       def translate_module_block_decl: (AST::Declarations::BlockDecl block, _Content rbs) -> void
+
+      # @rbs block: AST::Declarations::BlockDecl
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_class_block_decl: (AST::Declarations::BlockDecl block, _Content rbs) -> void
     end
   end
 end

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -39,6 +39,12 @@ module RBS
       # @rbs return: void
       def translate_class_decl: (AST::Declarations::ClassDecl decl, _Content rbs) -> void
 
+      # @rbs members: Array[AST::Declarations::t | AST::Members::t]
+      # @rbs decl: AST::Declarations::SingletonClassDecl?
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_members: (Array[AST::Declarations::t | AST::Members::t] members, AST::Declarations::SingletonClassDecl? decl, _Content rbs) -> void
+
       # @rbs decl: AST::Declarations::ModuleDecl
       # @rbs rbs: _Content
       # @rbs return: void
@@ -80,6 +86,11 @@ module RBS
       # @rbs decl: AST::Declarations::SingletonClassDecl?
       # @rbs return: RBS::AST::Members::MethodDefinition::kind
       def method_kind: (AST::Members::RubyDef member, AST::Declarations::SingletonClassDecl? decl) -> RBS::AST::Members::MethodDefinition::kind
+
+      # @rbs block: AST::Declarations::BlockDecl
+      # @rbs rbs: _Content
+      # @rbs return: void
+      def translate_module_block_decl: (AST::Declarations::BlockDecl block, _Content rbs) -> void
     end
   end
 end

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -695,5 +695,5 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
       assert_empty annotation.type_params
       assert_empty annotation.self_types
     end
-end
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -747,4 +747,26 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_block__class_decl
+    output = translate(<<~RUBY)
+      class Account
+        # @rbs class ::ApplicationController
+        controller do
+          def foo #: Integer
+            123
+          end
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class Account
+        # @rbs class ::ApplicationController
+        class ::ApplicationController
+          def foo: () -> Integer
+        end
+      end
+    RBS
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -707,4 +707,44 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_block__no_module
+    output = translate(<<~RUBY)
+      module M
+        class_methods do
+          def foo #: Integer
+            123
+          end
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      module M
+        def foo: () -> Integer
+      end
+    RBS
+  end
+
+  def test_block__module_decl
+    output = translate(<<~RUBY)
+      module M
+        # @rbs module ClassMethods[A] : BasicObject
+        class_methods do
+          def foo #: Integer
+            123
+          end
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      module M
+        # @rbs module ClassMethods[A] : BasicObject
+        module ClassMethods[A] : BasicObject
+          def foo: () -> Integer
+        end
+      end
+    RBS
+  end
 end


### PR DESCRIPTION
Some method calls with blocks implicitly defines a class/module or switch the method definition context. One of the most popular example would be `ActiveSupport::Concern`.

```rb
module Foo
  extend ActiveSupport::Concern

  class_methods do
    def foo = 123
  end
end
```

The `#class_methods` defines `ClassMethods` module that will be `extend`-ed into a class/module where `Foo` is `include`-ed.

To support the coding pattern, `rbs-inline` introduces `@rbs class` and `@rbs module` annotations.

```rb
module Foo
  extend ActiveSupport::Concern

  # @rbs module ClassMethods
  class_methods do
    # @rbs () -> Integer
    def foo = 123
  end
end
```

The `@rbs module` annotation attached to `class_methods` call defines a module called `ClassMethods` and put the method definitions inside the module.

```rbs
# output

module Foo
  module ClassMethods
    def foo: () -> Integer
  end
end
```