### PR TITLE
Improve top-level handling

### DIFF
--- a/lib/rbs/inline/cli.rb
+++ b/lib/rbs/inline/cli.rb
@@ -139,10 +139,10 @@ module RBS
 
           logger.debug { "Parsing ruby file #{target}..." }
 
-          if (uses, decls = Parser.parse(Prism.parse_file(target.to_s), opt_in: opt_in))
+          if (uses, decls, rbs_decls = Parser.parse(Prism.parse_file(target.to_s), opt_in: opt_in))
             writer = Writer.new()
             writer.header("Generated from #{target.relative? ? target : target.relative_path_from(Pathname.pwd)} with RBS::Inline")
-            writer.write(uses, decls)
+            writer.write(uses, decls, rbs_decls)
 
             if output
               unless output.parent.directory?

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -197,6 +197,8 @@ module RBS
           push_class_module_decl(singleton_decl) do
             visit node.body
           end
+
+          load_inner_annotations(node.location.start_line, node.location.end_line, singleton_decl.members)
         end
       end
 
@@ -435,6 +437,8 @@ module RBS
           push_class_module_decl(block) do
             super
           end
+
+          load_inner_annotations(node.location.start_line, node.location.end_line, block.members)
         end
       end
     end

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -227,6 +227,7 @@ module RBS
       # @rbs override
       def visit_alias_method_node(node)
         return if ignored_node?(node)
+        return unless current_class_module_decl
 
         if node.location
           comment = comments.delete(node.location.start_line - 1)

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -21,9 +21,10 @@ module RBS
 
       # @rbs uses: Array[AST::Annotations::Use]
       # @rbs decls: Array[AST::Declarations::t]
-      def self.write(uses, decls) #: void
+      # @rbs rbs_decls: Array[RBS::AST::Declarations::t]
+      def self.write(uses, decls, rbs_decls) #: void
         writer = Writer.new()
-        writer.write(uses, decls)
+        writer.write(uses, decls, rbs_decls)
         writer.output
       end
 
@@ -38,8 +39,10 @@ module RBS
 
       # @rbs uses: Array[AST::Annotations::Use]
       # @rbs decls: Array[AST::Declarations::t]
+      # @rbs rbs_decls: Array[RBS::AST::Declarations::t] --
+      #    Top level `rbs!` declarations
       # @rbs return: void
-      def write(uses, decls)
+      def write(uses, decls, rbs_decls)
         use_dirs = uses.map do |use|
           RBS::AST::Directives::Use.new(
             clauses: use.clauses,
@@ -55,6 +58,8 @@ module RBS
             rbs #: Array[RBS::AST::Declarations::t | RBS::AST::Members::t]
           )
         end
+
+        rbs.concat(rbs_decls)
 
         writer.write(
           use_dirs + rbs

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -72,6 +72,15 @@ module RBS
           translate_module_decl(decl, rbs)
         when AST::Declarations::ConstantDecl
           translate_constant_decl(decl, rbs)
+        when AST::Declarations::BlockDecl
+          if decl.module_class_annotation
+            case decl.module_class_annotation
+            when AST::Annotations::ModuleDecl
+              translate_module_block_decl(decl, rbs)
+            when AST::Annotations::ClassDecl
+              translate_class_block_decl(decl, rbs)
+            end
+          end
         end
       end
 
@@ -112,13 +121,8 @@ module RBS
           when AST::Declarations::SingletonClassDecl
             translate_singleton_decl(member, rbs)
           when AST::Declarations::BlockDecl
-            if annotation = member.module_class_annotation
-              case annotation
-              when AST::Annotations::ModuleDecl
-                translate_module_block_decl(member, rbs)
-              when AST::Annotations::ClassDecl
-                translate_class_block_decl(member, rbs)
-              end
+            if member.module_class_annotation
+              translate_decl(member, rbs)
             else
               translate_members(member.members, decl, rbs)
             end

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -104,6 +104,9 @@ module RBS
       # @rbs return: void
       def push_visibility: (RBS::AST::Members::visibility? new_visibility) { () -> void } -> void
 
+      # @rbs [A] (Node) { () -> A } -> A?
+      def process_nesting_node: [A] (Node) { () -> A } -> A?
+
       # @rbs node: Node
       # @rbs return: bool
       def ignored_node?: (Node node) -> bool

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -32,10 +32,21 @@ module RBS
 
       def initialize: () -> void
 
+      # Parses the given Prism result to a three tuple
+      #
+      # Returns a three tuple of:
+      #
+      # 1. An array of `use` directives
+      # 2. An array of declarations
+      # 3. An array of RBS declarations given as `@rbs!` annotation at top-level
+      #
+      # Note that only RBS declarations are allowed in the top-level `@rbs!` annotations.
+      # RBS *members* are ignored in the array.
+      #
       # @rbs result: ParseResult
       # @rbs opt_in: bool -- `true` for *opt-out* mode, `false` for *opt-in* mode.
-      # @rbs return: [Array[AST::Annotations::Use], Array[AST::Declarations::t]]?
-      def self.parse: (ParseResult result, opt_in: bool) -> [ Array[AST::Annotations::Use], Array[AST::Declarations::t] ]?
+      # @rbs return: [Array[AST::Annotations::Use], Array[AST::Declarations::t], Array[RBS::AST::Declarations::t]]?
+      def self.parse: (ParseResult result, opt_in: bool) -> [ Array[AST::Annotations::Use], Array[AST::Declarations::t], Array[RBS::AST::Declarations::t] ]?
 
       # @rbs return: with_members?
       def current_class_module_decl: () -> with_members?

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -18,7 +18,8 @@ module RBS
 
       # @rbs uses: Array[AST::Annotations::Use]
       # @rbs decls: Array[AST::Declarations::t]
-      def self.write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls) -> void
+      # @rbs rbs_decls: Array[RBS::AST::Declarations::t]
+      def self.write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls, Array[RBS::AST::Declarations::t] rbs_decls) -> void
 
       # @rbs *lines: String
       # @rbs return: void
@@ -26,8 +27,10 @@ module RBS
 
       # @rbs uses: Array[AST::Annotations::Use]
       # @rbs decls: Array[AST::Declarations::t]
+      # @rbs rbs_decls: Array[RBS::AST::Declarations::t] --
+      #    Top level `rbs!` declarations
       # @rbs return: void
-      def write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls) -> void
+      def write: (Array[AST::Annotations::Use] uses, Array[AST::Declarations::t] decls, Array[RBS::AST::Declarations::t] rbs_decls) -> void
 
       # @rbs decl: AST::Declarations::t
       # @rbs rbs: _Content

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -823,4 +823,36 @@ class RBS::Inline::WriterTest < Minitest::Test
     assert_equal <<~RBS, output
     RBS
   end
+
+  def test_module_block_annotations
+    output = translate(<<~RUBY)
+      # @rbs module ClassMethods
+      class_methods do
+        # @rbs @size: Integer
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      # @rbs module ClassMethods
+      module ClassMethods
+        @size: Integer
+      end
+    RBS
+  end
+
+  def test_sclass_annotations
+    output = translate(<<~RUBY)
+      class String
+        class <<self
+          # @rbs! self.@name: String
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class String
+        self.@name: String
+      end
+    RBS
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -769,4 +769,34 @@ class RBS::Inline::WriterTest < Minitest::Test
       end
     RBS
   end
+
+  def test_toplevel_definitions
+    output = translate(<<~RUBY)
+      NAME = "rbs_inline"
+
+      def foo = 123
+
+      alias bar foo
+
+      # @rbs module ApplicationController
+      controller do
+        def foo
+        end
+      end
+
+      class <<self
+        def foo
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      NAME: ::String
+
+      # @rbs module ApplicationController
+      module ApplicationController
+        def foo: () -> untyped
+      end
+    RBS
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -811,4 +811,16 @@ class RBS::Inline::WriterTest < Minitest::Test
       type foo = String
     RBS
   end
+
+  def test_only_toplevel_rbs!
+    output = translate(<<~RUBY)
+      # @rbs skip
+      module Foo
+        # @rbs! type bar = Symbol
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+    RBS
+  end
 end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -7,8 +7,8 @@ class RBS::Inline::WriterTest < Minitest::Test
 
   def translate(src, opt_in: true)
     src = "# rbs_inline: enabled\n\n" + src
-    uses, decls = Parser.parse(Prism.parse(src, filepath: "a.rb"), opt_in: opt_in)
-    Writer.write(uses, decls)
+    uses, decls, rbs_decls = Parser.parse(Prism.parse(src, filepath: "a.rb"), opt_in: opt_in)
+    Writer.write(uses, decls, rbs_decls)
   end
 
   def test_method_type
@@ -797,6 +797,18 @@ class RBS::Inline::WriterTest < Minitest::Test
       module ApplicationController
         def foo: () -> untyped
       end
+    RBS
+  end
+
+  def test_toplevel_rbs!
+    output = translate(<<~RUBY)
+      # @rbs!
+      #   type foo = String
+      #   alias foo bar
+    RUBY
+
+    assert_equal <<~RBS, output
+      type foo = String
     RBS
   end
 end


### PR DESCRIPTION
Let top level block calls or `@rbs!` annotations generate RBS definitions.