### PR TITLE
Define `.new` instaed of `#initialize` for Data and Struct

### DIFF
--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -208,14 +208,14 @@ module RBS
           )
         end
 
-        init = RBS::AST::Members::MethodDefinition.new(
-          name: :initialize,
-          kind: :instance,
+        new = RBS::AST::Members::MethodDefinition.new(
+          name: :new,
+          kind: :singleton,
           overloads: [
             RBS::AST::Members::MethodDefinition::Overload.new(
               method_type: RBS::MethodType.new(
                 type_params: [],
-                type: Types::Function.empty(Types::Bases::Void.new(location: nil)).update(
+                type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).update(
                   required_positionals: decl.each_attribute.map do |name, attr|
                     RBS::Types::Function::Param.new(
                       type: attr&.type || Types::Bases::Any.new(location: nil),
@@ -232,7 +232,7 @@ module RBS
             RBS::AST::Members::MethodDefinition::Overload.new(
               method_type: RBS::MethodType.new(
                 type_params: [],
-                type: Types::Function.empty(Types::Bases::Void.new(location: nil)).update(
+                type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).update(
                   required_keywords: decl.each_attribute.map do |name, attr|
                     [
                       name,
@@ -260,7 +260,7 @@ module RBS
         rbs << RBS::AST::Declarations::Class.new(
           name: decl.constant_name,
           type_params: [],
-          members: [*attributes, init],
+          members: [*attributes, new],
           super_class: RBS::AST::Declarations::Class::Super.new(
             name: RBS::TypeName.new(name: :Data, namespace: RBS::Namespace.empty),
             args: [],
@@ -307,9 +307,9 @@ module RBS
           end
         end
 
-        init = RBS::AST::Members::MethodDefinition.new(
-          name: :initialize,
-          kind: :instance,
+        new = RBS::AST::Members::MethodDefinition.new(
+          name: :new,
+          kind: :singleton,
           overloads: [],
           annotations: [],
           location: nil,
@@ -327,14 +327,14 @@ module RBS
             )
           end
 
-          method_type = Types::Function.empty(Types::Bases::Void.new(location: nil))
+          method_type = Types::Function.empty(Types::Bases::Instance.new(location: nil))
           if decl.required_new_args?
             method_type = method_type.update(required_positionals: attr_params)
           else
             method_type = method_type.update(optional_positionals: attr_params)
           end
 
-          init.overloads <<
+          new.overloads <<
             RBS::AST::Members::MethodDefinition::Overload.new(
               method_type: RBS::MethodType.new(type_params: [], type: method_type, block: nil, location: nil),
               annotations: []
@@ -353,14 +353,14 @@ module RBS
             ]
           end.to_h #: Hash[Symbol, RBS::Types::Function::Param]
 
-          method_type = Types::Function.empty(Types::Bases::Void.new(location: nil))
+          method_type = Types::Function.empty(Types::Bases::Instance.new(location: nil))
           if decl.required_new_args?
             method_type = method_type.update(required_keywords: attr_keywords)
           else
             method_type = method_type.update(optional_keywords: attr_keywords)
           end
 
-          init.overloads <<
+          new.overloads <<
             RBS::AST::Members::MethodDefinition::Overload.new(
               method_type: RBS::MethodType.new(type_params: [], type: method_type, block: nil, location: nil),
               annotations: []
@@ -370,7 +370,7 @@ module RBS
         rbs << RBS::AST::Declarations::Class.new(
           name: decl.constant_name,
           type_params: [],
-          members: [*attributes, init],
+          members: [*attributes, new],
           super_class: RBS::AST::Declarations::Class::Super.new(
             name: RBS::TypeName.new(name: :Struct, namespace: RBS::Namespace.empty),
             args: [RBS::Types::Bases::Any.new(location: nil)],

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -883,16 +883,16 @@ class RBS::Inline::WriterTest < Minitest::Test
 
         attr_reader email(): String
 
-        def initialize: (Integer id, String email) -> void
-                      | (id: Integer, email: String) -> void
+        def self.new: (Integer id, String email) -> instance
+                    | (id: Integer, email: String) -> instance
       end
 
       class Account
         class Group < Data
           attr_reader name(): untyped
 
-          def initialize: (untyped name) -> void
-                        | (name: untyped) -> void
+          def self.new: (untyped name) -> instance
+                      | (name: untyped) -> instance
         end
       end
     RBS
@@ -935,15 +935,15 @@ class RBS::Inline::WriterTest < Minitest::Test
 
         attr_accessor email(): String
 
-        def initialize: (?Integer id, ?String email) -> void
-                      | (?id: Integer, ?email: String) -> void
+        def self.new: (?Integer id, ?String email) -> instance
+                    | (?id: Integer, ?email: String) -> instance
       end
 
       class Account
         class Group < Struct[untyped]
           attr_accessor name(): untyped
 
-          def initialize: (?name: untyped) -> void
+          def self.new: (?name: untyped) -> instance
         end
       end
 
@@ -952,7 +952,7 @@ class RBS::Inline::WriterTest < Minitest::Test
 
         attr_accessor price(): Integer
 
-        def initialize: (?String sku, ?Integer price) -> void
+        def self.new: (?String sku, ?Integer price) -> instance
       end
 
       # @rbs %a{rbs-inline:new-args=required}
@@ -962,8 +962,8 @@ class RBS::Inline::WriterTest < Minitest::Test
       class User < Struct[untyped]
         attr_reader name(): String
 
-        def initialize: (String name) -> void
-                      | (name: String) -> void
+        def self.new: (String name) -> instance
+                    | (name: String) -> instance
       end
     RBS
   end


### PR DESCRIPTION
`Data` and `Struct` has customized `.new` methods, which prevents blocks `.new` methods in their sub-classes. This is because the automatic `.new` method type generation works only for `Class#new` method. Changing the behavior of RBS-gem may result in another problem, so we keep it.

This PR defines `.new` methods instead of `#initialize` in each sub-class, and the Data/Struct sub-classes will have typed `.new` methods.