### PR TITLE
Skip dependabot metadata check

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,12 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - name: Dependabot metadata
-        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 # v2.2.0
-        id: metadata
-      - name: Abort if Dependabot metadata doesn't set
-        run: exit 1
-        if: ${{ !startsWith(steps.metadata.outputs.update-type, 'version-update:') }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
While the [README](https://github.com/dependabot/fetch-metadata?tab=readme-ov-file#usage-instructions) says:

> By default, these outputs will only be populated if the target Pull Request was opened by Dependabot and contains only Dependabot-created commits.

But it looks like the metadata is set with a [PR](https://github.com/soutaro/rbs-inline/pull/88) with both dependabot commit and @soutaro's commit.

<img width="1012" alt="スクリーンショット 2024-08-27 12 44 19" src="https://github.com/user-attachments/assets/d4fe04b1-0588-4b56-bdd4-d0529fb13631">

Deleting the steps to avoid confusion.