### PR TITLE
Fix visibility of methods within `class << self`

### DIFF
--- a/lib/rbs/inline/ast/declarations.rb
+++ b/lib/rbs/inline/ast/declarations.rb
@@ -241,6 +241,21 @@ module RBS
         end
 
         class SingletonClassDecl < ModuleOrClass #[Prism::SingletonClassNode]
+          # @rbs (AST::Members::RubyDef) -> (:private | nil)
+          def visibility(def_member)
+            current_visibility = nil
+            members.each do |member|
+              case member
+              when AST::Members::RubyPublic
+                current_visibility = nil
+              when AST::Members::RubyPrivate
+                current_visibility = :private
+              end
+
+              break if member == def_member
+            end
+            current_visibility
+          end
         end
 
         class BlockDecl < Base

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -421,6 +421,7 @@ module RBS
             return
           end
 
+          visibility = member.visibility || decl&.visibility(member)
           rbs << RBS::AST::Members::MethodDefinition.new(
             name: member.method_name,
             kind: kind,
@@ -429,7 +430,7 @@ module RBS
             location: nil,
             comment: comment,
             overloading: member.overloading?,
-            visibility: member.visibility
+            visibility: visibility
           )
         when AST::Members::RubyAlias
           if member.comments
@@ -453,9 +454,9 @@ module RBS
             rbs.concat m
           end
         when AST::Members::RubyPrivate
-          rbs << RBS::AST::Members::Private.new(location: nil)
+          rbs << RBS::AST::Members::Private.new(location: nil) unless decl
         when AST::Members::RubyPublic
-          rbs << RBS::AST::Members::Public.new(location: nil)
+          rbs << RBS::AST::Members::Public.new(location: nil) unless decl
         when AST::Members::RBSIvar
           if m = member.rbs
             rbs << m

--- a/sig/generated/rbs/inline/ast/declarations.rbs
+++ b/sig/generated/rbs/inline/ast/declarations.rbs
@@ -115,6 +115,8 @@ module RBS
         end
 
         class SingletonClassDecl < ModuleOrClass[Prism::SingletonClassNode]
+          # @rbs (AST::Members::RubyDef) -> (:private | nil)
+          def visibility: (AST::Members::RubyDef) -> (:private | nil)
         end
 
         class BlockDecl < Base

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -656,6 +656,37 @@ class RBS::Inline::WriterTest < Minitest::Test
     RBS
   end
 
+  def test_singleton_class_definition__visibility
+    output = translate(<<~RUBY)
+      class X
+        class << self
+          private
+
+          def foo
+          end
+
+          def bar
+          end
+
+          public
+
+          def buz
+          end
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class X
+        private def self.foo: () -> untyped
+
+        private def self.bar: () -> untyped
+
+        def self.buz: () -> untyped
+      end
+    RBS
+  end
+
   def test_method_type_rbs_dot3
     output = translate(<<~RUBY)
       class X


### PR DESCRIPTION
When we use a `private` method within `class << self`, rbs-inline generates
wrong RBS declarations as follows.

```ruby
# ruby
class A
  class << self
    private
    def m; end
  end
end

# rbs generated by rbs-inline
class A
  private

  def self.m: () -> untyped
end
```

To solve this problem, add `private` to the RBS for all private singleton methods.

Also, since RBS does not support `class << self` syntax, there is
no need to output `public` and `private` within `class << self`.
