### PR TITLE
Include `self.members` and `members` method definitions in RBS generated by `Data.define`

### DIFF
--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -257,10 +257,40 @@ module RBS
           visibility: nil
         )
 
+        members = [:singleton, :instance].map do |kind|
+          RBS::AST::Members::MethodDefinition.new(
+            name: :members,
+            kind: kind, #: RBS::AST::MethodDefinition::Kind
+            overloads: [
+              RBS::AST::Members::MethodDefinition::Overload.new(
+                method_type: RBS::MethodType.new(
+                  type_params: [],
+                  type: Types::Function.empty(
+                    Types::Tuple.new(
+                      types: decl.each_attribute.map do |name, _|
+                        Types::Literal.new(literal: name, location: nil)
+                      end,
+                      location: nil
+                    )
+                  ),
+                  block: nil,
+                  location: nil
+                ),
+                annotations: []
+              )
+            ],
+            annotations: [],
+            location: nil,
+            comment: nil,
+            overloading: false,
+            visibility: nil
+          )
+        end
+
         rbs << RBS::AST::Declarations::Class.new(
           name: decl.constant_name,
           type_params: [],
-          members: [*attributes, new],
+          members: [*attributes, new, *members],
           super_class: RBS::AST::Declarations::Class::Super.new(
             name: RBS::TypeName.new(name: :Data, namespace: RBS::Namespace.empty),
             args: [],

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -916,6 +916,10 @@ class RBS::Inline::WriterTest < Minitest::Test
 
         def self.new: (Integer id, String email) -> instance
                     | (id: Integer, email: String) -> instance
+
+        def self.members: () -> [ :id, :email ]
+
+        def members: () -> [ :id, :email ]
       end
 
       class Account
@@ -924,6 +928,10 @@ class RBS::Inline::WriterTest < Minitest::Test
 
           def self.new: (untyped name) -> instance
                       | (name: untyped) -> instance
+
+          def self.members: () -> [ :name ]
+
+          def members: () -> [ :name ]
         end
       end
     RBS


### PR DESCRIPTION
This change ensures that the RBS generated for classes defined via `Data.define` 
includes type definitions for the `self.members` and `members` methods. 
These methods return the list of attributes defined by `Data.define`,and their absence in the RBS was previously a missing feature.

```ruby
irb(main):001> Foo = Data.define(:x, :y, :z)
=> Foo
irb(main):002> Foo.members
=> [:x, :y, :z]
irb(main):003> Foo.new(1,2,3).members
=> [:x, :y, :z]
```