### PR TITLE
Add overload for `self.new` method when using `keyword_init: true` with `Struct.new`

### DIFF
--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -365,6 +365,29 @@ module RBS
               method_type: RBS::MethodType.new(type_params: [], type: method_type, block: nil, location: nil),
               annotations: []
             )
+
+          unless decl.positional_init?
+            new.overloads <<
+              RBS::AST::Members::MethodDefinition::Overload.new(
+                method_type: RBS::MethodType.new(
+                  type_params: [],
+                  type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).then do |t|
+                    t.update(required_positionals: [
+                      RBS::Types::Function::Param.new(
+                        type: RBS::Types::Record.new(all_fields: decl.each_attribute.map do |name, attr|
+                          [name, attr&.type || Types::Bases::Any.new(location: nil)]
+                        end.to_h, location: nil),
+                        name: nil,
+                        location: nil
+                      )
+                    ])
+                  end,
+                  block: nil,
+                  location: nil
+                ),
+                annotations:[]
+              )
+          end
         end
 
         rbs << RBS::AST::Declarations::Class.new(

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -975,6 +975,7 @@ class RBS::Inline::WriterTest < Minitest::Test
           attr_accessor name(): untyped
 
           def self.new: (?name: untyped) -> instance
+                      | ({ ?name: untyped }) -> instance
         end
       end
 


### PR DESCRIPTION
This update enhances `rbs-inline` by adding an overload for the `self.new` method in the RBS generated for classes defined using `Struct.new` with the `keyword_init: true` option. With this change, the `self.new` method correctly accepts a Hash as an argument only when `keyword_init: true` is specified.

When using `Struct.new` with `keyword_init: true`, the `self.new` method accepts a Hash as follows:

```ruby
irb(main):004> Foo = Struct.new(:x, :y, keyword_init: true)
=> Foo(keyword_init: true)
irb(main):005> Bar = Struct.new(:x, :y)
=> Bar
irb(main):006> Foo.new({x: 1})
=> #<struct Foo x=1, y=nil>
irb(main):007> Bar.new({x: 1})
=> #<struct Bar x={:x=>1}, y=nil>
irb(main):008> Baz = Struct.new(:x, :y, keyword_init: false)
=> Baz
irb(main):009> Baz.new({x: 1})
=> #<struct Baz x={:x=>1}, y=nil>
```