### PR TITLE
Ignore top-level constructs

### DIFF
--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -274,6 +274,7 @@ module RBS
       # @rbs override
       def visit_call_node(node)
         return if ignored_node?(node)
+        return super unless current_class_module_decl
 
         case node.name
         when :include, :prepend, :extend

--- a/test/rbs/inline/parser_test.rb
+++ b/test/rbs/inline/parser_test.rb
@@ -158,4 +158,18 @@ class RBS::Inline::ParserTest < Minitest::Test
       end
     end
   end
+
+  def test_toplevel__constructs
+    Parser.parse(parse_ruby(<<~RUBY), opt_in: false)
+      include Foo
+      extend Bar
+      prepend Baz
+
+      public
+      private
+
+      def foo
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Mixin, method definition, `public`/`private` can be written, but `rbs-inline` silently ignores them.