### PR TITLE
parser: Do not parse inside method defs

### DIFF
--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -254,8 +254,6 @@ module RBS
           assertion = assertion_annotation(node.rparen_loc || node&.parameters&.location || node.name_loc)
 
           current_decl.members << AST::Members::RubyDef.new(node, associated_comment, current_visibility, assertion)
-
-          super
         end
       end
 

--- a/test/rbs/inline/parser_test.rb
+++ b/test/rbs/inline/parser_test.rb
@@ -172,4 +172,27 @@ class RBS::Inline::ParserTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_def_decl
+    _, decls = Parser.parse(parse_ruby(<<~RUBY), opt_in: false)
+      class Account
+        def foo
+          # Do not parse definitions inside methods
+          def bar; end
+
+          private
+        end
+      end
+    RUBY
+
+    assert_equal 1, decls.size
+    decls[0].tap do |decl|
+      assert_instance_of AST::Declarations::ClassDecl, decl
+      assert_equal 1, decl.members.size
+      decl.members[0].tap do |member|
+        assert_instance_of AST::Members::RubyDef, member
+        assert_equal :foo, member.node.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
Not to avoid misdetection, this stops parsing inside method definitions.

Fix #111