### PR TITLE
Support module_function

### DIFF
--- a/lib/rbs/inline/ast/members.rb
+++ b/lib/rbs/inline/ast/members.rb
@@ -41,6 +41,10 @@ module RBS
           # ```
           attr_reader :visibility #: RBS::AST::Members::visibility?
 
+          # The function is defined as singleton and instance method (as known as module_function)
+          #
+          attr_accessor :singleton_instance #: bool
+
           # Assertion given at the end of the method name
           #
           attr_reader :assertion #: Annotations::TypeAssertion?
@@ -48,11 +52,13 @@ module RBS
           # @rbs node: Prism::DefNode
           # @rbs comments: AnnotationParser::ParsingResult?
           # @rbs visibility: RBS::AST::Members::visibility?
+          # @rbs singleton_instance: bool
           # @rbs assertion: Annotations::TypeAssertion?
-          def initialize(node, comments, visibility, assertion) #: void
+          def initialize(node, comments, visibility, singleton_instance, assertion) #: void
             @node = node
             @comments = comments
             @visibility = visibility
+            @singleton_instance = singleton_instance
             @assertion = assertion
 
             super(node.location)

--- a/lib/rbs/inline/parser.rb
+++ b/lib/rbs/inline/parser.rb
@@ -37,10 +37,14 @@ module RBS
       #
       attr_reader :current_visibility #: RBS::AST::Members::visibility?
 
+      # The current module_function applied to single `def` node
+      attr_reader :current_module_function #: bool
+
       def initialize() #: void
         @decls = []
         @surrounding_decls = []
         @comments = {}
+        @current_module_function = false
       end
 
       # Parses the given Prism result to a three tuple
@@ -253,7 +257,7 @@ module RBS
 
           assertion = assertion_annotation(node.rparen_loc || node&.parameters&.location || node.name_loc)
 
-          current_decl.members << AST::Members::RubyDef.new(node, associated_comment, current_visibility, assertion)
+          current_decl.members << AST::Members::RubyDef.new(node, associated_comment, current_visibility, current_module_function, assertion)
 
           super
         end
@@ -330,6 +334,30 @@ module RBS
                 return
               end
             end
+          end
+        when :module_function
+          if node.arguments && node.arguments.arguments.size > 0
+            args = node.arguments.arguments.filter_map do |arg|
+              case arg
+              when Prism::SymbolNode
+                arg.unescaped.to_sym
+              end
+            end
+
+            current_decl = current_class_module_decl
+
+            if current_decl
+              node.arguments.arguments.each do |arg|
+                current_decl.members.each do |member|
+                  if member.is_a?(AST::Members::RubyDef) && args.include?(member.node.name)
+                    member.singleton_instance = true
+                    break
+                  end
+                end
+              end
+            end
+          else
+            @current_module_function = true
           end
         end
 

--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -542,6 +542,7 @@ module RBS
       # @rbs return: RBS::AST::Members::MethodDefinition::kind
       def method_kind(member, decl)
         return :singleton if decl
+        return :singleton_instance if member.singleton_instance
 
         case member.node.receiver
         when Prism::SelfNode

--- a/sig/generated/rbs/inline/ast/members.rbs
+++ b/sig/generated/rbs/inline/ast/members.rbs
@@ -37,14 +37,18 @@ module RBS
           # ```
           attr_reader visibility: RBS::AST::Members::visibility?
 
+          # The function is defined as singleton and instance method (as known as module_function)
+          attr_accessor singleton_instance: bool
+
           # Assertion given at the end of the method name
           attr_reader assertion: Annotations::TypeAssertion?
 
           # @rbs node: Prism::DefNode
           # @rbs comments: AnnotationParser::ParsingResult?
           # @rbs visibility: RBS::AST::Members::visibility?
+          # @rbs singleton_instance: bool
           # @rbs assertion: Annotations::TypeAssertion?
-          def initialize: (Prism::DefNode node, AnnotationParser::ParsingResult? comments, RBS::AST::Members::visibility? visibility, Annotations::TypeAssertion? assertion) -> void
+          def initialize: (Prism::DefNode node, AnnotationParser::ParsingResult? comments, RBS::AST::Members::visibility? visibility, bool singleton_instance, Annotations::TypeAssertion? assertion) -> void
 
           # Returns the name of the method
           def method_name: () -> Symbol

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -30,6 +30,9 @@ module RBS
       # `nil` when the `def` node is not inside `private` or `public` calls.
       attr_reader current_visibility: RBS::AST::Members::visibility?
 
+      # The current module_function applied to single `def` node
+      attr_reader current_module_function: bool
+
       def initialize: () -> void
 
       # Parses the given Prism result to a three tuple

--- a/test/rbs/inline/parser_test.rb
+++ b/test/rbs/inline/parser_test.rb
@@ -167,6 +167,7 @@ class RBS::Inline::ParserTest < Minitest::Test
 
       public
       private
+      module_function
 
       def foo
       end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -205,6 +205,34 @@ class RBS::Inline::WriterTest < Minitest::Test
     RBS
   end
 
+  def test_method_type__module_function
+    output = translate(<<~RUBY)
+      module Foo
+        def f()
+        end
+
+        def g()
+        end
+        module_function :g
+
+        module_function
+
+        def h()
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      module Foo
+        def f: () -> untyped
+
+        def self?.g: () -> untyped
+
+        def self?.h: () -> untyped
+      end
+    RBS
+  end
+
   def test_method_type__visibility
     output = translate(<<~RUBY)
       class Foo


### PR DESCRIPTION
Detect `module_function` calls and add `self?.` prefix to the definitions.