### PR TITLE
docs: Remove Important notice about experimental syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 RBS::Inline allows embedding RBS type declarations into Ruby code as comments. You can declare types, write the implementation, and verifies they are consistent without leaving the editor opening the Ruby code.
 
 > [!IMPORTANT]
-> The syntax is experimental. We are still seeking the best syntax with your feedbacks.
-
-> [!IMPORTANT]
 > This gem is a prototype for testing. We plan to merge this feature to rbs-gem and deprecate rbs-inline gem after that.
 
 > [!NOTE]


### PR DESCRIPTION
soutaro announces the annotation syntax has matured.  Therefore it's time to remove the experimental label, right?

refs: https://speakerdeck.com/euglena1215/install-rbs-inline-and-migrate-from-yard-to-rbs?slide=16