### PR TITLE
Proposal: Allow using type assertion comment for module-selfs

### DIFF
--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -12,7 +12,7 @@ module RBS
         #          | Generic
         #          | ModuleSelf
         #          | Skip
-        #          | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion
+        #          | MethodTypeAssertion | TypeAssertion | MultipleTypeAssertion | SyntaxErrorAssertion | Dot3Assertion
         #          | Application
         #          | RBSAnnotation
         #          | Override
@@ -334,6 +334,23 @@ module RBS
 
           def type_source #: String
             type.location&.source || raise
+          end
+        end
+
+        class MultipleTypeAssertion < Base
+          attr_reader :types #: Array[Types::t]
+
+          # @rbs override
+          def initialize(tree, source)
+            @source = source
+            @tree = tree
+
+            @types = []
+            tree.non_trivia_trees.size.times do |i|
+              if tree.nth_type?(i)
+                types << tree.nth_type!(i)
+              end
+            end
           end
         end
 

--- a/sig/generated/rbs/inline/annotation_parser.rbs
+++ b/sig/generated/rbs/inline/annotation_parser.rbs
@@ -155,8 +155,8 @@ module RBS
       #
       # @rbs tokenizer: Tokenizer
       # @rbs parent_tree: AST::Tree
-      # @rbs return: MethodType | AST::Tree | Types::t | nil
-      def parse_type_method_type: (Tokenizer tokenizer, AST::Tree parent_tree) -> (MethodType | AST::Tree | Types::t | nil)
+      # @rbs return: MethodType | AST::Tree | Types::t | Array[Types::t | token] | nil
+      def parse_type_method_type: (Tokenizer tokenizer, AST::Tree parent_tree) -> (MethodType | AST::Tree | Types::t | Array[Types::t | token] | nil)
 
       # Parse a RBS method type
       #

--- a/sig/generated/rbs/inline/ast/annotations.rbs
+++ b/sig/generated/rbs/inline/ast/annotations.rbs
@@ -4,7 +4,7 @@ module RBS
   module Inline
     module AST
       module Annotations
-        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType | ModuleDecl | ClassDecl
+        type t = VarType | ReturnType | Use | Inherits | Generic | ModuleSelf | Skip | MethodTypeAssertion | TypeAssertion | MultipleTypeAssertion | SyntaxErrorAssertion | Dot3Assertion | Application | RBSAnnotation | Override | IvarType | Embedded | Method | SplatParamType | DoubleSplatParamType | BlockType | ModuleDecl | ClassDecl
 
         module Utils
           # @rbs (Tree) -> RBS::AST::TypeParam?
@@ -126,6 +126,13 @@ module RBS
           def initialize: ...
 
           def type_source: () -> String
+        end
+
+        class MultipleTypeAssertion < Base
+          attr_reader types: Array[Types::t]
+
+          # @rbs override
+          def initialize: ...
         end
 
         class SyntaxErrorAssertion < Base

--- a/sig/generated/rbs/inline/ast/declarations.rbs
+++ b/sig/generated/rbs/inline/ast/declarations.rbs
@@ -73,6 +73,14 @@ module RBS
         class ModuleDecl < ModuleOrClass[Prism::ModuleNode]
           include ConstantUtil
 
+          attr_reader module_self_assertion: Annotations::TypeAssertion | Annotations::MultipleTypeAssertion | nil
+
+          # @rbs node: Prism::ModuleNode
+          # @rbs comments: AnnotationParser::ParsingResult?
+          # @rbs module_self_assertion: Annotations::TypeAssertion | Annotations::MultipleTypeAssertion | nil
+          # @rbs return: void
+          def initialize: (Prism::ModuleNode node, AnnotationParser::ParsingResult? comments, Annotations::TypeAssertion | Annotations::MultipleTypeAssertion | nil module_self_assertion) -> void
+
           # @rbs %a{pure}
           %a{pure}
           def module_name: () -> TypeName?

--- a/sig/generated/rbs/inline/parser.rbs
+++ b/sig/generated/rbs/inline/parser.rbs
@@ -130,6 +130,14 @@ module RBS
       # @rbs return: AST::Annotations::TypeAssertion?
       def assertion_annotation: (Node | Location node) -> AST::Annotations::TypeAssertion?
 
+      # Fetch TypeAssertion or MultipleTypeAssertion annotation which is associated to `node`
+      #
+      # The assertion annotation is removed from `comments`.
+      #
+      # @rbs node: Node | Location
+      # @rbs return: AST::Annotations::TypeAssertion | AST::Annotations::MultipleTypeAssertion | nil
+      def module_self_annotation: (Node | Location node) -> (AST::Annotations::TypeAssertion | AST::Annotations::MultipleTypeAssertion | nil)
+
       # @rbs override
       def visit_constant_write_node: ...
 

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -153,6 +153,7 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
   def test_type_assertion
     annots = AnnotationParser.parse(parse_comments(<<~RUBY))
       #: [Integer, String]
+      #: Integer, String
       #: [Integer
       # : String
       RUBY
@@ -162,6 +163,12 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
       assert_equal "[ Integer, String ]", annotation.type.to_s
     end
     annots[0].annotations[1].tap do |annotation|
+      assert_instance_of AST::Annotations::MultipleTypeAssertion, annotation
+      assert_equal 2, annotation.types.size
+      assert_equal "Integer", annotation.types[0].to_s
+      assert_equal "String", annotation.types[1].to_s
+    end
+    annots[0].annotations[2].tap do |annotation|
       assert_instance_of AST::Annotations::SyntaxErrorAssertion, annotation
       assert_equal "[Integer\n : String", annotation.error_string
     end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -489,6 +489,36 @@ class RBS::Inline::WriterTest < Minitest::Test
     RBS
   end
 
+  def test_module_self__type_assertion
+    output = translate(<<~RUBY)
+      module Foo #: BasicObject
+        def foo
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      module Foo : BasicObject
+        def foo: () -> untyped
+      end
+    RBS
+  end
+
+  def test_module_self__multiple_type_assertions
+    output = translate(<<~RUBY)
+      module Foo #: BasicObject, Integer
+        def foo
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      module Foo : BasicObject, Integer
+        def foo: () -> untyped
+      end
+    RBS
+  end
+
   def test_constant_decl
     output = translate(<<~RUBY)
       VERSION = "hogehoge"


### PR DESCRIPTION
This allows using type assertion comment to define module-selfs on module declaration:

```ruby
module Foo #: String
end
```

This is same as `# @rbs module-self: String`.