### PR TITLE
Support attr_accessors for singleton class

### DIFF
--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -503,8 +503,12 @@ module RBS
             rbs << m
           end
         when AST::Members::RubyAttr
-          if m = member.rbs
-            rbs.concat m
+          if decl
+            rbs.concat translate_singleton_ruby_attr(member)
+          else
+            if m = member.rbs
+              rbs.concat m
+            end
           end
         when AST::Members::RubyPrivate
           rbs << RBS::AST::Members::Private.new(location: nil) unless decl
@@ -624,6 +628,122 @@ module RBS
           RBS::BuiltinNames::Hash.instance_type(untyped, untyped)
         else
           type
+        end
+      end
+
+      # @rbs member: AST::Members::RubyAttr
+      # @rbs return: Array[RBS::AST::Members::t]
+      def translate_singleton_ruby_attr(member)
+        rbs = []
+        if %i[attr_accessor attr_reader].include?(member.node.name)
+          if m = translate_singleton_ruby_attr_reader(member)
+            rbs.concat m
+          end
+        end
+        if %i[attr_accessor attr_writer].include?(member.node.name)
+          if m = translate_singleton_ruby_attr_writer(member)
+            rbs.concat m
+          end
+        end
+
+        rbs
+      end
+
+      # @rbs member: AST::Members::RubyAttr
+      # @rbs return: Array[RBS::AST::Members::t]?
+      def translate_singleton_ruby_attr_reader(member)
+        if member.node.arguments
+          if member.comments
+            comment = RBS::AST::Comment.new(string: member.comments.content(trim: true), location: nil)
+          end
+          member.node.arguments.arguments.filter_map do |arg|
+            if arg.is_a?(Prism::SymbolNode)
+              type = RBS::Types::Function.new(
+                required_positionals: [],
+                optional_positionals: [],
+                rest_positionals: nil,
+                trailing_positionals: [],
+                required_keywords: {},
+                optional_keywords: {},
+                rest_keywords: nil,
+                return_type: member.attribute_type,
+              )
+              method_type = RBS::MethodType.new(
+                type_params: [],
+                type: type,
+                block: nil,
+                location: nil
+              )
+              overload = RBS::AST::Members::MethodDefinition::Overload.new(
+                method_type: method_type,
+                annotations: []
+              )
+              annotation = RBS::AST::Annotation.new(string: 'pure', location: nil)
+
+              name = arg.value or raise
+              RBS::AST::Members::MethodDefinition.new(
+                name: name.to_sym,
+                kind: :singleton,
+                overloads: [overload],
+                annotations: [annotation],
+                comment: comment,
+                overloading: false,
+                visibility: nil,
+                location: nil
+              )
+            end
+          end
+        end
+      end
+
+      # @rbs member: AST::Members::RubyAttr
+      # @rbs return: Array[RBS::AST::Members::t]?
+      def translate_singleton_ruby_attr_writer(member)
+        if member.node.arguments
+          if member.comments
+            comment = RBS::AST::Comment.new(string: member.comments.content(trim: true), location: nil)
+          end
+          member.node.arguments.arguments.filter_map do |arg|
+            if arg.is_a?(Prism::SymbolNode)
+              param = RBS::Types::Function::Param.new(
+                type: member.attribute_type,
+                name: nil,
+                location: nil
+              )
+              type = RBS::Types::Function.new(
+                required_positionals: [param],
+                optional_positionals: [],
+                rest_positionals: nil,
+                trailing_positionals: [],
+                required_keywords: {},
+                optional_keywords: {},
+                rest_keywords: nil,
+                return_type: member.attribute_type,
+              )
+              method_type = RBS::MethodType.new(
+                type_params: [],
+                type: type,
+                block: nil,
+                location: nil
+              )
+              overload = RBS::AST::Members::MethodDefinition::Overload.new(
+                method_type: method_type,
+                annotations: []
+              )
+
+              name = arg.value or raise
+              RBS::AST::Members::MethodDefinition.new(
+                name: "#{name}=".to_sym,
+                kind: :singleton,
+                overloads: [overload],
+                annotations: [],
+                comment: comment,
+                overloading: false,
+                visibility: nil,
+                location: nil
+              )
+            end
+          end
         end
       end
 

--- a/sig/generated/rbs/inline/writer.rbs
+++ b/sig/generated/rbs/inline/writer.rbs
@@ -112,6 +112,18 @@ module RBS
       # @rbs return: RBS::Types::t
       def constant_decl_to_type: (AST::Declarations::ConstantDecl decl) -> RBS::Types::t
 
+      # @rbs member: AST::Members::RubyAttr
+      # @rbs return: Array[RBS::AST::Members::t]
+      def translate_singleton_ruby_attr: (AST::Members::RubyAttr member) -> Array[RBS::AST::Members::t]
+
+      # @rbs member: AST::Members::RubyAttr
+      # @rbs return: Array[RBS::AST::Members::t]?
+      def translate_singleton_ruby_attr_reader: (AST::Members::RubyAttr member) -> Array[RBS::AST::Members::t]?
+
+      # @rbs member: AST::Members::RubyAttr
+      # @rbs return: Array[RBS::AST::Members::t]?
+      def translate_singleton_ruby_attr_writer: (AST::Members::RubyAttr member) -> Array[RBS::AST::Members::t]?
+
       # @rbs return: RBS::Types::Bases::Any
       def untyped: () -> RBS::Types::Bases::Any
     end

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -413,6 +413,73 @@ class RBS::Inline::WriterTest < Minitest::Test
     RBS
   end
 
+  def test_singleton_attributes__unannotated
+    output = translate(<<~RUBY)
+      class Hello
+        class << self
+          attr_reader :foo, :foo2, "hoge".to_sym
+
+          # Attribute of bar
+          attr_writer :bar
+
+          attr_accessor :baz
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class Hello
+        %a{pure}
+        def self.foo: () -> untyped
+
+        %a{pure}
+        def self.foo2: () -> untyped
+
+        # Attribute of bar
+        def self.bar=: (untyped) -> untyped
+
+        %a{pure}
+        def self.baz: () -> untyped
+
+        def self.baz=: (untyped) -> untyped
+      end
+    RBS
+  end
+
+  def test_singleton_attributes__typed
+    output = translate(<<~RUBY)
+      class Hello
+        class << self
+          attr_reader :foo, :foo2, "hoge".to_sym #: String
+
+          # Attribute of bar
+          attr_writer :bar #: Array[Integer]
+
+          attr_accessor :baz #: Integer |
+        end
+      end
+    RUBY
+
+    assert_equal <<~RBS, output
+      class Hello
+        %a{pure}
+        def self.foo: () -> String
+
+        %a{pure}
+        def self.foo2: () -> String
+
+        # Attribute of bar
+        def self.bar=: (Array[Integer]) -> Array[Integer]
+
+        %a{pure}
+        def self.baz: () -> untyped
+
+        def self.baz=: (untyped) -> untyped
+      end
+    RBS
+  end
+
+
   def test_public_private
     output = translate(<<~RUBY)
       class Hello


### PR DESCRIPTION
To support attr_accessor, reader and writer for singleton class, this converts them to the mere method definitions.

```ruby
class Foo
  class << self
    attr_accessor :bar
  end
end
```

The above code will converted into the followings:

```ruby
class Foo
  %a{pure}
  def self.bar: () -> untyped
  def self.bar=: (untyped) -> untyped
end
```