### PR TITLE
Load stringio gem explicitly

### DIFF
--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -1,5 +1,7 @@
 # rbs_inline: enabled
 
+require 'stringio'
+
 module RBS
   module Inline
     class Writer


### PR DESCRIPTION
Make sure to load stringio gem, this adds a require statement to writer.rb.

On my local, RBS::Inline failed to load it:

```
tkomiya@tarf> bundle exec rbs-inline --opt-out --output app
/Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
/Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs-inline-0.9.0/lib/rbs/inline/writer.rb:19:in `initialize': uninitialized constant RBS::Inline::Writer::StringIO (NameError)

        @writer = RBS::Writer.new(out: StringIO.new(buffer))
                                       ^^^^^^^^
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs-inline-0.9.0/lib/rbs/inline/cli.rb:143:in `new'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs-inline-0.9.0/lib/rbs/inline/cli.rb:143:in `block in run'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs-inline-0.9.0/lib/rbs/inline/cli.rb:124:in `each'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs-inline-0.9.0/lib/rbs/inline/cli.rb:124:in `run'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs-inline-0.9.0/exe/rbs-inline:6:in `<top (required)>'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bin/rbs-inline:25:in `load'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bin/rbs-inline:25:in `<top (required)>'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/cli.rb:455:in `exec'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/cli.rb:35:in `dispatch'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/cli.rb:29:in `start'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/exe/bundle:28:in `block in <top (required)>'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/exe/bundle:20:in `<top (required)>'
	from /Users/tkomiya/.rbenv/versions/3.3.5/bin/bundle:25:in `load'
	from /Users/tkomiya/.rbenv/versions/3.3.5/bin/bundle:25:in `<main>'
```


```
# Gemfile
# frozen_string_literal: true

source "https://rubygems.org"

gem "rbs-inline", require: false
gem "railties"
```