### PR TITLE
docs: Remove recommendation for steep version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ RBS::Inline allows embedding RBS type declarations into Ruby code as comments. Y
 > [!IMPORTANT]
 > This gem is a prototype for testing. We plan to merge this feature to rbs-gem and deprecate rbs-inline gem after that.
 
-> [!NOTE]
-> Use Steep >= `1.8.0.dev` to avoid the conflicts on `#:` syntax.
-
 Here is a quick example of embedded declarations.
 
 ```rb


### PR DESCRIPTION
Now steep-1.8.x has already been shipped.  So mentions are no longer needed.