### PR TITLE
Use shorter syntax in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,31 @@ Here is a quick example of embedded declarations.
 
 class Person
   attr_reader :name #: String
+
   attr_reader :addresses #: Array[String]
 
-  #: (name: String, addresses: Array[String]) -> void
+  # You can write the type of parameters and return types.
+  #
+  # @rbs name: String
+  # @rbs addresses: Array[String]
+  # @rbs return: void
   def initialize(name:, addresses:)
     @name = name
     @addresses = addresses
   end
 
-  def to_s #: String
+  # Or write the type of the method just after `@rbs` keyword.
+  #
+  # @rbs () -> String
+  def to_s
     "Person(name = #{name}, addresses = #{addresses.join(", ")})"
+  end
+
+  # The `:` syntax is the shortest one.
+  #
+  #: () -> String
+  def hash
+    [name, addresses].hash
   end
 
   # @rbs &block: (String) -> void

--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ Here is a quick example of embedded declarations.
 
 class Person
   attr_reader :name #: String
-
   attr_reader :addresses #: Array[String]
 
-  # @rbs name: String
-  # @rbs addresses: Array[String]
-  # @rbs return: void
+  #: (name: String, addresses: Array[String]) -> void
   def initialize(name:, addresses:)
     @name = name
     @addresses = addresses


### PR DESCRIPTION
Just from a quick glance at the README, it's not obvious that there's a shorter single-line syntax that could be used instead of the multiple `# @rbs name: Type` lines.

When I showed this repo to several coworkers, they all got the mistaken impression that the signitures _have_ to be multiple lines like JavaDoc or JSDoc.

To fix this, I suggest we highlight the short syntax in the first and main example.

Optionally, we could add another method as an example of the longer syntax, showing how it can be useful for methods with many parameters and/or long types, like this one:

https://github.com/soutaro/rbs-inline/blob/5b4885bce0ecf71f879ee2c1a1599cbd1c5d28cd/sig/generated/rbs/inline/ast/members.rbs#L109-L113