### PR TITLE
Use ruby/actions workflow for ruby versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,15 +8,18 @@ on:
   pull_request:
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 3.1
   build:
+    needs: ruby-versions
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby:
-          - '3.3'
-          - '3.2'
-          - '3.1'
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR uses the following to specify the matrix:
https://github.com/ruby/actions/blob/master/.github/workflows/ruby_versions.yml