### PR TITLE
Set the generics of the struct based on the type of its attributes

### DIFF
--- a/lib/rbs/inline/writer.rb
+++ b/lib/rbs/inline/writer.rb
@@ -428,7 +428,12 @@ module RBS
           members: [*attributes, new],
           super_class: RBS::AST::Declarations::Class::Super.new(
             name: RBS::TypeName.new(name: :Struct, namespace: RBS::Namespace.empty),
-            args: [RBS::Types::Bases::Any.new(location: nil)],
+            args: [
+              RBS::Types::Union.new(
+                types: decl.each_attribute.map { |_, attr| attr&.type || RBS::Types::Bases::Any.new(location: nil) }.uniq,
+                location: nil
+              )
+            ],
             location: nil
           ),
           annotations: decl.class_annotations,

--- a/test/rbs/inline/writer_test.rb
+++ b/test/rbs/inline/writer_test.rb
@@ -1011,7 +1011,7 @@ class RBS::Inline::WriterTest < Minitest::Test
 
     assert_equal <<~RBS, output
       # Account record
-      class Account < Struct[untyped]
+      class Account < Struct[Integer | String]
         attr_accessor id(): Integer
 
         attr_accessor email(): String
@@ -1029,7 +1029,7 @@ class RBS::Inline::WriterTest < Minitest::Test
         end
       end
 
-      class Item < Struct[untyped]
+      class Item < Struct[String | Integer]
         attr_accessor sku(): String
 
         attr_accessor price(): Integer
@@ -1041,7 +1041,7 @@ class RBS::Inline::WriterTest < Minitest::Test
       # @rbs %a{rbs-inline:readonly-attributes=true}
       %a{rbs-inline:new-args=required}
       %a{rbs-inline:readonly-attributes=true}
-      class User < Struct[untyped]
+      class User < Struct[String]
         attr_reader name(): String
 
         def self.new: (String name) -> instance


### PR DESCRIPTION
```rb
Account = Struct.new(
  :id,    #: Integer
  :email, #: String
)
```
This Ruby code generates the following RBS code:
```rbs
class Account < Struct[Integer | String]
  attr_accessor id(): Integer

  attr_accessor email(): String

  def self.new: (?Integer id, ?String email) -> instance
              | (?id: Integer, ?email: String) -> instance
end
```