### PR TITLE
fix: Deprecated warning for `Kernel#Namespace()`

### DIFF
--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -482,7 +482,7 @@ module RBS
                   case last_token
                   when Array
                     # `*` clause
-                    namespace = Namespace(token_strs.join)
+                    namespace = RBS::Namespace.parse(token_strs.join)
                     @clauses << RBS::AST::Directives::Use::WildcardClause.new(
                       namespace: namespace,
                       location: nil

--- a/test/rbs/inline/annotation_parser_test.rb
+++ b/test/rbs/inline/annotation_parser_test.rb
@@ -378,7 +378,7 @@ class RBS::Inline::AnnotationParserTest < Minitest::Test
       assert_instance_of AST::Annotations::Use, annotation
 
       annotation.clauses[0].tap do |clause|
-        assert_equal Namespace("Foo::"), clause.namespace
+        assert_equal RBS::Namespace.parse("Foo::"), clause.namespace
       end
     end
     annots[0].annotations[6].tap do |annotation|


### PR DESCRIPTION
Receive a deprecation warning for `Kernel#Namespace()` in RBS 3.8 or later.

```shell
$ bundle exec rbs --version
rbs 3.8.1

$ bundle exec rake test
Kernel#Namespace() is deprecated. Use RBS::Namespace.parse instead.
```

Use `RBS::Namespace.parse` instead of `Kernel#Namespace()`.

I have verified that the test passes on RBS 3.5, 3.6, 3.7, and 3.8.