### PR TITLE
deps: Update bundler to 2.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -90,4 +91,4 @@ DEPENDENCIES
   strscan
 
 BUNDLED WITH
-   2.5.16
+   2.6.3


### PR DESCRIPTION
The following error happens in GHA and updating Bundler will solve it.

```
The installation path is insecure. Bundler cannot continue.
```

ref: https://github.com/rubygems/rubygems/issues/7983#issuecomment-2623808193