### PR TITLE
Remove upper bound constraint on prism dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rbs-inline (0.11.0)
-      prism (>= 0.29, < 1.3)
+      prism (>= 0.29)
       rbs (>= 3.5.0)
 
 GEM

--- a/rbs-inline.gemspec
+++ b/rbs-inline.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "prism", ">= 0.29", "< 1.3"
+  spec.add_dependency "prism", ">= 0.29"
   spec.add_dependency "rbs", ">= 3.5.0"
 end


### PR DESCRIPTION
## Summary
I encountered a version conflict with the prism library when trying to introduce rbs-inline, as it conflicts with other libraries in my project. I have removed the upper version limit for prism.
ref: https://github.com/soutaro/rbs-inline/pull/199#discussion_r2037811188


## Alternative
Currently, I need prism 1.4 in my environment, so merging [this PR](https://github.com/soutaro/rbs-inline/pull/199) would resolve the issue for me.