### PR TITLE
deps: Update dependency to RBS to 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem "rake", "~> 13.2"
 
 gem "minitest", "~> 5.25"
 
-gem "steep", "~> 1.10.0", require: false
+gem "steep", "~> 2.0.0", require: false
 gem "strscan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,37 +3,18 @@ PATH
   specs:
     rbs-inline (0.13.0)
       prism (>= 0.29)
-      rbs (>= 3.8.0)
+      rbs (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     ast (2.4.3)
-    base64 (0.3.0)
-    bigdecimal (4.1.2)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
     csv (3.3.5)
-    drb (2.2.3)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
-    i18n (1.14.8)
-      concurrent-ruby (~> 1.0)
     json (2.19.4)
     language_server-protocol (3.17.0.5)
     listen (3.10.0)
@@ -42,7 +23,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     minitest (5.27.0)
-    mutex_m (0.3.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -53,12 +33,12 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.4)
+    rbs (4.0.2)
       logger
+      prism (>= 1.6.0)
       tsort
     securerandom (0.4.1)
-    steep (1.10.0)
-      activesupport (>= 5.1)
+    steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -66,10 +46,10 @@ GEM
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.1)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.9)
+      rbs (~> 4.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
@@ -78,8 +58,6 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     tsort (0.2.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -98,7 +76,7 @@ DEPENDENCIES
   minitest (~> 5.25)
   rake (~> 13.2)
   rbs-inline!
-  steep (~> 1.10.0)
+  steep (~> 2.0.0)
   strscan
 
 BUNDLED WITH

--- a/lib/rbs/inline/annotation_parser.rb
+++ b/lib/rbs/inline/annotation_parser.rb
@@ -527,10 +527,10 @@ module RBS
       # @rbs return: MethodType | AST::Tree | Types::t | nil
       def parse_type_method_type(tokenizer, parent_tree)
         tokenizer.consume_trivias(parent_tree)
-        buffer = RBS::Buffer.new(name: "", content: tokenizer.scanner.string)
-        range = (tokenizer.current_position..)
+        buffer = RBS::Buffer.new(name: Pathname.new(""), content: tokenizer.scanner.string)
+        byte_range = (tokenizer.current_position..)
         begin
-          if type = RBS::Parser.parse_method_type(buffer, range: range, require_eof: false)
+          if type = RBS::Parser.parse_method_type(buffer, byte_range: byte_range, require_eof: false)
             loc = type.location or raise
             tokenizer.reset(loc.end_pos, parent_tree)
             type
@@ -539,7 +539,7 @@ module RBS
           end
         rescue RBS::ParsingError
           begin
-            if type = RBS::Parser.parse_type(buffer, range: range, require_eof: false)
+            if type = RBS::Parser.parse_type(buffer, byte_range: byte_range, require_eof: false)
               loc = type.location or raise
               tokenizer.reset(loc.end_pos, parent_tree)
               type
@@ -566,10 +566,10 @@ module RBS
       # @rbs return: MethodType | AST::Tree
       def parse_method_type(tokenizer, parent_tree)
         tokenizer.consume_trivias(parent_tree)
-        buffer = RBS::Buffer.new(name: "", content: tokenizer.scanner.string)
-        range = (tokenizer.current_position..)
+        buffer = RBS::Buffer.new(name: Pathname.new(""), content: tokenizer.scanner.string)
+        byte_range = (tokenizer.current_position..)
         begin
-          if type = RBS::Parser.parse_method_type(buffer, range: range, require_eof: false)
+          if type = RBS::Parser.parse_method_type(buffer, byte_range: byte_range, require_eof: false)
             loc = type.location or raise
             tokenizer.reset(loc.end_pos, parent_tree)
             type
@@ -605,9 +605,9 @@ module RBS
       # @rbs return: Types::t | AST::Tree | nil
       def parse_type(tokenizer, parent_tree)
         tokenizer.consume_trivias(parent_tree)
-        buffer = RBS::Buffer.new(name: "", content: tokenizer.scanner.string)
-        range = (tokenizer.current_position..)
-        if type = RBS::Parser.parse_type(buffer, range: range, require_eof: false)
+        buffer = RBS::Buffer.new(name: Pathname.new(""), content: tokenizer.scanner.string)
+        byte_range = (tokenizer.current_position..)
+        if type = RBS::Parser.parse_type(buffer, byte_range: byte_range, require_eof: false)
           loc = type.location or raise
           tokenizer.reset(loc.end_pos, parent_tree)
           type

--- a/lib/rbs/inline/ast/annotations.rb
+++ b/lib/rbs/inline/ast/annotations.rb
@@ -59,6 +59,7 @@ module RBS
                 name: name.to_sym,
                 variance: inout,
                 upper_bound: upper_bound,
+                lower_bound: nil,
                 location: nil
               ).unchecked!(unchecked)
             end

--- a/rbs-inline.gemspec
+++ b/rbs-inline.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "prism", ">= 0.29"
-  spec.add_dependency "rbs", ">= 3.8.0"
+  spec.add_dependency "rbs", "~> 4.0"
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -10,15 +10,19 @@ gems:
   source:
     type: stdlib
 - name: logger
-  version: '0'
+  version: '1.7'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0c952bbd8da015cef73934ccb02ff60b48aee124
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: minitest
   version: '5.25'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d70d634c6e848dc5e93cea0163cc8206448be048
+    revision: 0c952bbd8da015cef73934ccb02ff60b48aee124
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -38,11 +42,11 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: d70d634c6e848dc5e93cea0163cc8206448be048
+    revision: 0c952bbd8da015cef73934ccb02ff60b48aee124
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs
-  version: 3.10.3
+  version: 4.0.2
   source:
     type: rubygems
 - name: rdoc


### PR DESCRIPTION
RBS-4.0 adds a new require keyword argument `lower_bound` to `RBS::AST::TypeParam#initialize`.  As a result, current RBS::Inline release does not work with RBS-4.0.

This updates the dependency to use RBS-4.0, and follows the new interface of `RBS::AST::TypeParam#initialize`.

Closes #242