### PR TITLE
deps: Move strscan to the dependency list in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,3 @@ gem "rake", "~> 13.2"
 gem "minitest", "~> 5.25"
 
 gem "steep", "~> 2.0.0", require: false
-gem "strscan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     rbs-inline (0.14.0)
       prism (>= 0.29)
       rbs (~> 4.0)
+      strscan
 
 GEM
   remote: https://rubygems.org/
@@ -77,7 +78,6 @@ DEPENDENCIES
   rake (~> 13.2)
   rbs-inline!
   steep (~> 2.0.0)
-  strscan
 
 BUNDLED WITH
   4.0.6

--- a/rbs-inline.gemspec
+++ b/rbs-inline.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "prism", ">= 0.29"
   spec.add_dependency "rbs", "~> 4.0"
+  spec.add_dependency "strscan"
 end


### PR DESCRIPTION
This moves the dependency entry for the strscan gem from the Gemfile to the gemspec.

RBS::Inline depends on the strscan gem.  At runtime, it's not required to add the gem to the dependency list because it is a bundled gem.

But, on the typing side, the dependency needs to be declared explicitly.

Reproducible steps:

```
$ bundle init
Writing new Gemfile to /Users/tkomiya/work/work/Gemfile
$ bundle add rbs-inline
Fetching gem metadata from https://rubygems.org/...
Resolving dependencies...
$ bundle install
Bundle complete! 1 Gemfile dependency, 5 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed
$ bundle exec rbs collection init
created: rbs_collection.yaml
$ bundle exec rbs collection install
(snip)
$ bundle exec rbs validate
E, [2026-07-07T15:04:23.128239 #50127] ERROR -- rbs: /Users/tkomiya/.dotfiles/_rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rbs-inline-0.14.0/sig/generated/rbs/inline/annotation_parser/tokenizer.rbs:115:29...115:42: Could not find StringScanner (RBS::NoTypeFoundError)

          attr_reader scanner: StringScanner
                               ^^^^^^^^^^^^^

```